### PR TITLE
Golem fix

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -329,21 +329,22 @@
 		playsound(loc, 'sound/effects/glass_step.ogg', 50, 1)
 		if(ishuman(AM))
 			var/mob/living/carbon/human/H = AM
-			var/check = H.lying ? H.w_uniform : H.shoes
-			if(!check)
-				var/obj/item/organ/limb/O = H.get_organ(pick("l_leg", "r_leg"))
-				H.apply_damage(5, BRUTE, O)
-				if(!H.lying) H.Weaken(3)
-				if(prob(embed_chance))
-					H.throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)
-					O.embedded_objects |= src
-					src.add_blood(H)//it embedded itself in you, of course it's bloody!
-					src.loc = H
-					H.visible_message("<span class='warning'>\The [src] has embedded into [H]'s [O.getDisplayName()]!</span>",
-									"<span class='userdanger'>You feel [src] lodge into your [O.getDisplayName()]!</span>")
-					H.update_damage_overlays() //Update the fancy embeds
-					H.emote("scream")
-				if(cooldown < world.time - 10) //cooldown to avoid message spam. Too bad this cooldown is only for the shard itself.
-					H.visible_message("<span class='danger'>[H] [H.lying ? "lays" : "steps"] in the broken glass!</span>", \
-							"<span class='userdanger'>You [H.lying ? "lay" : "step"] in the broken glass!</span>")
-					cooldown = world.time
+			if(!(PIERCEIMMUNE in H.dna.species.specflags))
+				var/check = H.lying ? H.w_uniform : H.shoes
+				if(!check)
+					var/obj/item/organ/limb/O = H.get_organ(pick("l_leg", "r_leg"))
+					H.apply_damage(5, BRUTE, O)
+					if(!H.lying) H.Weaken(3)
+					if(prob(embed_chance))
+						H.throw_alert("embeddedobject", /obj/screen/alert/embeddedobject)
+						O.embedded_objects |= src
+						src.add_blood(H)//it embedded itself in you, of course it's bloody!
+						src.loc = H
+						H.visible_message("<span class='warning'>\The [src] has embedded into [H]'s [O.getDisplayName()]!</span>",
+										"<span class='userdanger'>You feel [src] lodge into your [O.getDisplayName()]!</span>")
+						H.update_damage_overlays() //Update the fancy embeds
+						H.emote("scream")
+					if(cooldown < world.time - 10) //cooldown to avoid message spam. Too bad this cooldown is only for the shard itself.
+						H.visible_message("<span class='danger'>[H] [H.lying ? "lays" : "steps"] in the broken glass!</span>", \
+								"<span class='userdanger'>You [H.lying ? "lay" : "step"] in the broken glass!</span>")
+						cooldown = world.time

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -464,7 +464,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	name = "Adamantine Golem"
 	id = "adamantine"
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/golem/adamantine
-	specflags = list(NOBREATH,VIRUSIMMUNE,NOBLOOD,PIERCEIMMUNE,COLDRES, HEATRES, NOFIRE, NOGUNS)
+	specflags = list(NOBREATH,HEATRES,COLDRES,NOFIRE,NOGUNS,NOBLOOD,VIRUSIMMUNE,PIERCEIMMUNE)
 
 /*
  Mr. Meeseeks

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -464,7 +464,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	name = "Adamantine Golem"
 	id = "adamantine"
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/golem/adamantine
-	specflags = list(NOBREATH,VIRUSIMMUNE,NOBLOOD,PIERCEIMMUNE)
+	specflags = list(NOBREATH,VIRUSIMMUNE,NOBLOOD,PIERCEIMMUNE,COLDRES, HEATRES, NOFIRE, NOGUNS)
 
 /*
  Mr. Meeseeks

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -464,6 +464,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	name = "Adamantine Golem"
 	id = "adamantine"
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/golem/adamantine
+	specflags = list(NOBREATH,VIRUSIMMUNE,NOBLOOD,RADIMMUNE,PIERCEIMMUNE)
 
 /*
  Mr. Meeseeks
@@ -484,7 +485,6 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	no_equip = list(slot_wear_mask, slot_wear_suit, slot_gloves, slot_shoes, slot_head, slot_w_uniform)
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/meeseeks
 	nojumpsuit = 1
-	meat = null
 	exotic_blood = null //insert white blood later
 	say_mod = "yells"
 	var/stage = 1 //stage to control Meeseeks desperation

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -464,7 +464,7 @@ datum/species/human/spec_death(gibbed, mob/living/carbon/human/H)
 	name = "Adamantine Golem"
 	id = "adamantine"
 	meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/golem/adamantine
-	specflags = list(NOBREATH,VIRUSIMMUNE,NOBLOOD,RADIMMUNE,PIERCEIMMUNE)
+	specflags = list(NOBREATH,VIRUSIMMUNE,NOBLOOD,PIERCEIMMUNE)
 
 /*
  Mr. Meeseeks


### PR DESCRIPTION
added specflags = list(NOBREATH,VIRUSIMMUNE,NOBLOOD,PIERCEIMMUNE,COLDRES, HEATRES, NOFIRE, NOGUNS) to adamantine golems.
Some of these things used to be provided by clothes, which they don't apparently anymore have.
This means they take reduced damage from heat/cold (including lasers) and cant be set on fire, they wont bleed or catch a disease and neither can syringes be used on them, and they wont take damage for walking on dices or shards, or hitting things with shards. But as a downside, they are now too bulky to use guns.

Removed meat = null from meeseeks (as it also has meat = /obj/item/weapon/reagent_containers/food/snacks/meat/slab/human/mutant/meeseeks)

Made the glass shards check for if(!(PIERCEIMMUNE in H.dna.species.specflags)) when crossed.

Fixes: https://github.com/HippieStationCode/HippieStation13/issues/1696 and https://github.com/HippieStationCode/HippieStation13/issues/1055