### PR TITLE
Nerfs borg stun arm

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -10,7 +10,7 @@
 	icon_state = "elecarm"
 
 /obj/item/borg/stun/attack(mob/living/M, mob/living/silicon/robot/user)
-	if(!user.cell.use(30)) return
+	if(!user.cell.use(300)) return
 
 	M.Weaken(5)
 	M.apply_effect(STUTTER, 5)


### PR DESCRIPTION
It now costs 300 power instead of 30 power, which is basically free.

For comparison, the sec borg's stun baton costs 1000 power. Why a tool specifically designed to incapacitate humans with nonlethal electric shock costs 30 TIMES MORE POWER than the stun arm, I don't know.

Quite frankly the stun arm makes no sense. Realistically it'd just char the person to a crisp before it shocks them. 