### PR TITLE
Makes reactive teleport armor a researchable item and removes it from the RD's locker

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -65,12 +65,6 @@
 	difficulty = 3
 	excludefromjob = list("Head of Security", "Warden")
 
-/datum/objective_item/steal/reactive
-	name = "the reactive teleport armor"
-	targetitem = /obj/item/clothing/suit/armor/reactive
-	difficulty = 5
-	excludefromjob = list("Research Director")
-
 /datum/objective_item/steal/documents
 	name = "any set of secret documents of any organization"
 	targetitem = /obj/item/documents //Any set of secret documents. Doesn't have to be NT's

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -18,6 +18,5 @@
 	new /obj/item/device/radio/headset/heads/rd(src)
 	new /obj/item/weapon/tank/internals/air(src)
 	new /obj/item/clothing/mask/gas(src)
-	new /obj/item/clothing/suit/armor/reactive(src)
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/device/laser_pointer(src)

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -198,7 +198,7 @@
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0)
 	action_button_name = "Toggle Armor"
 	unacidable = 1
-	hit_reaction_chance = 50
+	hit_reaction_chance = 25
 
 /obj/item/clothing/suit/armor/reactive/attack_self(mob/user)
 	src.active = !( src.active )

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -274,3 +274,13 @@
 	materials = list(MAT_METAL = 2000, MAT_SILVER = 500)
 	build_path = /obj/item/weapon/suppressor
 	category = list("Weapons")
+	
+/datum/design/armor/reactive
+	name = "Reactive Teleport Armor"
+	desc= "Someone seperated our Research Director from his own head!"
+	id = "reactive"
+	req_tech = list("materials" = 7, "combat" = 6, "powerstorage" = 6, "magnets" = 6, "programming" = 6, "bluespace" = 7)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 25000, MAT_GLASS = 10000, MAT_SILVER = 20000, MAT_GOLD = 20000, MAT_PLASMA = 6000, MAT_DIAMOND = 2000)
+	build_path = /obj/item/clothing/suit/armor/reactive
+	category = list("Weapons")

--- a/html/changelogs/Sarcalogo Change.yml
+++ b/html/changelogs/Sarcalogo Change.yml
@@ -1,0 +1,7 @@
+ 
+author: Sarcalogo
+
+delete-after: True
+
+changes: 
+  - rscdel: "Removes the reactive teleport armor from the RD's office."


### PR DESCRIPTION
The reactive teleport armor has a fifty percent shot of activation and activates no matter what area you target, when coupled with the telescopic shield or riot shield (it always is) you're adding another fifty percent making the combined miss rate of of all projectiles 100 percent (obviously because it's two consecutive fifty percent's, it's a not a REAL 100 percent shot but you understand) It's used as all access, and you can use it to escape any sort of scenario in which you would be trapped. It's one downside was supposed to be that it could teleport you into an area which would be dangerous, but this is entirely bypassed by your ability to activate the armor yourself anytime you want. 

In practical terms, it's used by maximum power gaming security players and traitors to murder the entire station. It leads to boring one sided rounds where no fun is had by any except perhaps the wearer. It's gotten so bad that you'll have Captain's and HoS's who will immediately run to the RD's office to steal the armor in the first minute of the round. If you couple this with the telescopic shield, all access, chem implants, and ranged weapons you're nigh invincible if you're even 10 percent competent. Remove the armor and you'll have more balanced rounds. 