### PR TITLE
Conveyor switch

### DIFF
--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -207,6 +207,8 @@
 		for(var/obj/machinery/conveyor/C in machines)
 			if(C.id == id)
 				conveyors += C
+		spawn(5)
+			operated = 1
 
 // update the icon depending on the position
 


### PR DESCRIPTION
Made conveyor switch update the conveyor belts soon after the map is loaded.

Meaning that you just have to mapedit the switch on/off, and it will pass it on to linked belts soon after the map is loaded, instead of having to edit the switch and all the belts.

Technically a fix to disposals conveyors starting off even tho the switch is on, but also a mapping feature.