### PR TITLE
Gang tags only on walls

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -426,17 +426,21 @@
 
 			//Check area validity. Reject space, player-created areas, and non-station z-levels.
 			if(gangID)
-				territory = get_area(target)
-				if(territory && (territory.z == ZLEVEL_STATION) && territory.valid_territory)
-					//Check if this area is already tagged by a gang
-					if(!(locate(/obj/effect/decal/cleanable/crayon/gang) in target)) //Ignore the check if the tile being sprayed has a gang tag
-						if(territory_claimed(territory, user))
+				if(istype(target, /turf/simulated/wall))
+					territory = get_area(target)
+					if(territory && (territory.z == ZLEVEL_STATION) && territory.valid_territory)
+						//Check if this area is already tagged by a gang
+						if(!(locate(/obj/effect/decal/cleanable/crayon/gang) in target)) //Ignore the check if the tile being sprayed has a gang tag
+							if(territory_claimed(territory, user))
+								return
+						if(locate(/obj/machinery/power/apc) in (user.loc.contents | target.contents))
+							user << "<span class='warning'>You cannot tag here.</span>"
 							return
-					if(locate(/obj/machinery/power/apc) in (user.loc.contents | target.contents))
-						user << "<span class='warning'>You cannot tag here.</span>"
+					else
+						user << "<span class='warning'>[territory] is unsuitable for tagging.</span>"
 						return
 				else
-					user << "<span class='warning'>[territory] is unsuitable for tagging.</span>"
+					user << "<span class='warning'>You can only tag walls.</span>"
 					return
 		/////////////////////////////////////////
 

--- a/html/changelogs/Pyko - gangtags.yml
+++ b/html/changelogs/Pyko - gangtags.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Pyko
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Gang members can only spray their tags on walls."


### PR DESCRIPTION
Allows gangs tags only to be sprayed on walls.

Fixes https://github.com/HippieStationCode/HippieStation13/issues/1886