### PR TITLE
Burnt storages and GUI

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -169,6 +169,13 @@
 		return 1
 
 /obj/proc/burn()
+	if(istype(src, /obj/item/weapon/storage))
+		var/obj/item/weapon/storage/S = src
+		for(var/obj/Item in contents)
+			Item.mouse_opacity = initial(Item.mouse_opacity)
+		S.close_all()
+		qdel(S.boxes)
+		qdel(S.closer)
 	for(var/obj/item/Item in contents) //Empty out the contents
 		Item.loc = src.loc
 		Item.fire_act() //Set them on fire, too


### PR DESCRIPTION
Closes the GUI for any storage that is burned.

Fixes https://github.com/HippieStationCode/HippieStation13/issues/1903