### PR TITLE
Methamphetamine + Bath Salts Nerf

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
@@ -65,6 +65,14 @@
 	M.AdjustStunned(-1)
 	M.AdjustWeakened(-1)
 	..()
+	
+/datum/reagent/drug/crank/on_mob_delete(mob/living/M)
+	M.visible_message("<span class='danger'>[M] staggers and falls!</span>")
+	M.adjustToxLoss(current_cycle*0.1*REM)
+	M.AdjustWeakened(5*REM)
+	M.AdjustStunned(5*REM)
+	M.adjustStaminaLoss(25*REM)
+	return
 
 /datum/reagent/drug/crank/overdose_process(mob/living/M)
 	M.adjustBrainLoss(2*REM)
@@ -245,7 +253,7 @@
 	M.AdjustWeakened(-6)
 	M.adjustStaminaLoss(-10)
 	M.adjustToxLoss(0.1)
-	M.hallucination += 10
+	M.hallucination += 7.5
 	if(M.canmove && !istype(M.loc, /atom/movable))
 		step(M, pick(cardinal))
 		step(M, pick(cardinal))

--- a/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
@@ -147,7 +147,7 @@
 	description = "Reduces stun times by about 300%, speeds the user up, and allows the user to quickly recover stamina while dealing a small amount of Brain damage. If overdosed the subject will move randomly, laugh randomly, drop items and suffer from Toxin and Brain damage. If addicted the subject will constantly jitter and drool, before becoming dizzy and losing motor control and eventually suffer heavy toxin damage."
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
-	overdose_threshold = 20
+	overdose_threshold = 15
 	addiction_threshold = 10
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
 
@@ -161,10 +161,18 @@
 	M.adjustStaminaLoss(-2)
 	M.status_flags |= GOTTAGOREALLYFAST
 	M.Jitter(2)
-	M.adjustBrainLoss(0.25)
 	if(prob(5))
 		M.emote(pick("twitch", "shiver"))
 	..()
+	return
+	
+/datum/reagent/drug/methamphetamine/on_mob_delete(mob/living/M)
+	M.visible_message("<span class='danger'>[M] collapses in exhaustion!</span>")
+	M.adjustToxLoss(current_cycle*1*REM)
+	M.adjustBrainLoss(current_cycle*0.25*REM)
+	M.AdjustWeakened(5*REM)
+	M.AdjustStunned(5*REM)
+	M.adjustStaminaLoss(50*REM)
 	return
 
 /datum/reagent/drug/methamphetamine/overdose_process(mob/living/M)
@@ -224,7 +232,7 @@
 	description = "Makes you nearly impervious to stuns and grants a stamina regeneration buff, but you will be a nearly uncontrollable tramp-bearded raving lunatic."
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
-	overdose_threshold = 20
+	overdose_threshold = 15
 	addiction_threshold = 10
 
 
@@ -232,17 +240,25 @@
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
 	if(prob(5))
 		M << "<span class='notice'>[high_message]</span>"
-	M.AdjustParalysis(-3)
-	M.AdjustStunned(-3)
-	M.AdjustWeakened(-3)
-	M.adjustStaminaLoss(-5)
-	M.adjustBrainLoss(0.5)
+	M.AdjustParalysis(-6)
+	M.AdjustStunned(-6)
+	M.AdjustWeakened(-6)
+	M.adjustStaminaLoss(-10)
 	M.adjustToxLoss(0.1)
 	M.hallucination += 10
 	if(M.canmove && !istype(M.loc, /atom/movable))
 		step(M, pick(cardinal))
 		step(M, pick(cardinal))
 	..()
+	return
+	
+/datum/reagent/drug/bath_salts/on_mob_delete(mob/living/M)
+	M.visible_message("<span class='danger'>[M] goes pale and collapses!</span>")
+	M.adjustToxLoss(current_cycle*1.5*REM)
+	M.adjustBrainLoss(current_cycle*0.5*REM)
+	M.AdjustWeakened(8*REM)
+	M.AdjustStunned(8*REM)
+	M.adjustStaminaLoss(50*REM)
 	return
 
 /datum/reagent/drug/bath_salts/overdose_process(mob/living/M)

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -474,7 +474,7 @@
 		var/obj/item/I = M.get_active_hand()
 		if(I)
 			M.drop_item()
-			M.visible_message("<span class='danger'>[M] shudders and drops something on the floor!</span>")
+			M.visible_message("<span class='danger'>[M] shudders and drops [I] on the floor!</span>")
 	..()
 	return
 

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -450,22 +450,31 @@
 	reagent_state = LIQUID
 	color = "#C8A5DC"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	overdose_threshold = 45
+	overdose_threshold = 30
 	addiction_threshold = 30
 
 /datum/reagent/medicine/ephedrine/on_mob_life(mob/living/M)
 	M.status_flags |= GOTTAGOFAST
-	M.AdjustParalysis(-1)
-	M.AdjustStunned(-1)
-	M.AdjustWeakened(-1)
-	M.adjustStaminaLoss(-1*REM)
+	M.AdjustParalysis(-0.4)
+	M.AdjustStunned(-0.4)
+	M.AdjustWeakened(-0.4)
+	M.adjustStaminaLoss(-0.5*REM)
 	..()
 	return
+
+/datum/reagent/medicine/ephedrine/on_mob_delete(mob/living/M)
+	M.visible_message("<span class='danger'>[M] suddenly runs out of breath!</span>")
+	M.adjustStaminaLoss(50*REM)
 
 /datum/reagent/medicine/ephedrine/overdose_process(mob/living/M)
 	if(prob(33))
 		M.adjustToxLoss(0.5*REM)
 		M.losebreath++
+	if(prob(12))
+		var/obj/item/I = M.get_active_hand()
+		if(I)
+			M.drop_item()
+			M.visible_message("<span class='danger'>[M] shudders and drops something on the floor!</span>")
 	..()
 	return
 

--- a/code/modules/reagents/Chemistry-Recipes/Drugs.dm
+++ b/code/modules/reagents/Chemistry-Recipes/Drugs.dm
@@ -36,8 +36,8 @@
 	name = "bath_salts"
 	id = "bath_salts"
 	result = "bath_salts"
-	required_reagents = list("????" = 1, "saltpetre" = 1, "nutriment" = 1, "cleaner" = 1, "enzyme" = 1, "tea" = 1, "mercury" = 1)
-	result_amount = 7
+	required_reagents = list("????" = 1, "saltpetre" = 1, "nutriment" = 1, "cleaner" = 1, "tea" = 1, "mercury" = 1)
+	result_amount = 6
 	required_temp = 374
 
 /datum/chemical_reaction/aranesp

--- a/html/changelogs/Kierany9 - Meth Balance.yml
+++ b/html/changelogs/Kierany9 - Meth Balance.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Kierany9
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Methamphetamine and Bath Salts now stun and deal toxin damage once they wear off."
+  - tweak: "Removed Enzyme from the Bath Salts recepie to prevent it from creating moonshine."

--- a/html/changelogs/Kierany9 - Meth Balance.yml
+++ b/html/changelogs/Kierany9 - Meth Balance.yml
@@ -33,5 +33,7 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Methamphetamine and Bath Salts now stun and deal toxin damage once they wear off."
+  - tweak: "General Stimulant balancing:"
+  - tweak: "Methamphetamine, Crank, Bath Salts and Ephedrine now deal stun and varying degrees of toxin damage damage once they wear off."
+  - tweak: "Reduced Meth's and Bath Salt's overdose threshold from 20 to 15 and Ephedrine's fom 45 to 30"
   - tweak: "Removed Enzyme from the Bath Salts recepie to prevent it from creating moonshine."

--- a/html/changelogs/Kierany9 - Meth Balance.yml
+++ b/html/changelogs/Kierany9 - Meth Balance.yml
@@ -35,5 +35,6 @@ delete-after: True
 changes: 
   - tweak: "General Stimulant balancing:"
   - tweak: "Methamphetamine, Crank, Bath Salts and Ephedrine now deal stun and varying degrees of toxin damage damage once they wear off."
-  - tweak: "Reduced Meth's and Bath Salt's overdose threshold from 20 to 15 and Ephedrine's fom 45 to 30"
+  - tweak: "Reduced Meth's and Bath Salt's overdose threshold from 20 to 15 and Ephedrine's fom 45 to 30."
+  - tweak: "Ephedrine now causes you to drop items on overdose."
   - tweak: "Removed Enzyme from the Bath Salts recepie to prevent it from creating moonshine."


### PR DESCRIPTION
These changes have been made to bring meth in line with the other stimulants and makes Bath Salts actually worth using either as a poison or stimulant as well as fixing its recepie. Currently there is no reason to use any other stimulant(except Adrenal Implants) over meth, as it is one of the easiest to make(can make 80u in about 30 seconds) and has no side effects of any severity. Crank is much weaker, harder to make and is more harmful, Ephendrine is weaker but much safer and Bath Salts has so many side effects it's not even funny.

- Nerfs Methamphetamine and Bath Salts, causing a stun and brain, stamina and toxin damage (scales with how long the drug was in the player's system) once the drug wears off.
- Lowers overdose threshold on both drugs to 15.
- Brain damage only takes effect once the drugs wear off.
- Doubled stun resistances and stamina regen on Bath Salts.
- Slightly reduced Bath Salt's hallucinations.
- Removed Enzyme from Bath Salts recepie, Enzyme and Nutriment would react to create moonshine before the Bath Salts could form.

- Ephedrine now causes stamina damage once worn off and Crank causes stun, stamina and toxin damage.
- Lowers overdose threshold on Ephedrine to 30.
- Ephedrine overdose now causes you to drop items.
- Reduced stun resistance and stamina regen on Ephedrine.