### PR TITLE
Anti-stun update quickfix

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
@@ -67,11 +67,14 @@
 	..()
 	
 /datum/reagent/drug/crank/on_mob_delete(mob/living/M)
-	M.visible_message("<span class='danger'>[M] staggers and falls!</span>")
 	M.adjustToxLoss(current_cycle*0.1*REM)
-	M.AdjustWeakened(5*REM)
-	M.AdjustStunned(5*REM)
-	M.adjustStaminaLoss(25*REM)
+	if(current_cycle >= 5)
+		M.visible_message("<span class='danger'>[M] staggers and falls!</span>")
+		M.AdjustWeakened(5*REM)
+		M.AdjustStunned(5*REM)
+		M.adjustStaminaLoss(25*REM)
+	else
+		M.adjustStaminaLoss(current_cycle*5*REM)
 	return
 
 /datum/reagent/drug/crank/overdose_process(mob/living/M)
@@ -175,12 +178,15 @@
 	return
 	
 /datum/reagent/drug/methamphetamine/on_mob_delete(mob/living/M)
-	M.visible_message("<span class='danger'>[M] collapses in exhaustion!</span>")
 	M.adjustToxLoss(current_cycle*1*REM)
 	M.adjustBrainLoss(current_cycle*0.25*REM)
-	M.AdjustWeakened(5*REM)
-	M.AdjustStunned(5*REM)
-	M.adjustStaminaLoss(50*REM)
+	if(current_cycle >= 5)
+		M.visible_message("<span class='danger'>[M] collapses in exhaustion!</span>")
+		M.AdjustWeakened(5*REM)
+		M.AdjustStunned(5*REM)
+		M.adjustStaminaLoss(25*REM)
+	else
+		M.adjustStaminaLoss(current_cycle*5*REM)
 	return
 
 /datum/reagent/drug/methamphetamine/overdose_process(mob/living/M)
@@ -261,12 +267,15 @@
 	return
 	
 /datum/reagent/drug/bath_salts/on_mob_delete(mob/living/M)
-	M.visible_message("<span class='danger'>[M] goes pale and collapses!</span>")
 	M.adjustToxLoss(current_cycle*1.5*REM)
 	M.adjustBrainLoss(current_cycle*0.5*REM)
-	M.AdjustWeakened(8*REM)
-	M.AdjustStunned(8*REM)
-	M.adjustStaminaLoss(50*REM)
+	if(current_cycle >= 5)
+		M.visible_message("<span class='danger'>[M] goes pale and collapses!</span>")
+		M.AdjustWeakened(8*REM)
+		M.AdjustStunned(8*REM)
+		M.adjustStaminaLoss(50*REM)
+	else
+		M.adjustStaminaLoss(current_cycle*10*REM)
 	return
 
 /datum/reagent/drug/bath_salts/overdose_process(mob/living/M)

--- a/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
@@ -72,9 +72,9 @@
 		M.visible_message("<span class='danger'>[M] staggers and falls!</span>")
 		M.AdjustWeakened(5*REM)
 		M.AdjustStunned(5*REM)
-		M.adjustStaminaLoss(25*REM)
+		M.adjustStaminaLoss(20*REM)
 	else
-		M.adjustStaminaLoss(current_cycle*5*REM)
+		M.adjustStaminaLoss(current_cycle*4*REM)
 	return
 
 /datum/reagent/drug/crank/overdose_process(mob/living/M)
@@ -184,9 +184,9 @@
 		M.visible_message("<span class='danger'>[M] collapses in exhaustion!</span>")
 		M.AdjustWeakened(5*REM)
 		M.AdjustStunned(5*REM)
-		M.adjustStaminaLoss(25*REM)
+		M.adjustStaminaLoss(35*REM)
 	else
-		M.adjustStaminaLoss(current_cycle*5*REM)
+		M.adjustStaminaLoss(current_cycle*7*REM)
 	return
 
 /datum/reagent/drug/methamphetamine/overdose_process(mob/living/M)

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -463,8 +463,11 @@
 	return
 
 /datum/reagent/medicine/ephedrine/on_mob_delete(mob/living/M)
-	M.visible_message("<span class='danger'>[M] suddenly runs out of breath!</span>")
-	M.adjustStaminaLoss(50*REM)
+	if(current_cycle >= 10)
+		M.visible_message("<span class='danger'>[M] suddenly runs out of breath!</span>")
+		M.adjustStaminaLoss(50*REM)
+	else
+		M.adjustStaminaLoss(current_cycle*5*REM)
 
 /datum/reagent/medicine/ephedrine/overdose_process(mob/living/M)
 	if(prob(33))


### PR DESCRIPTION
Quick fix to a couple of things I managed to mess up with my last PR that nobody caught. Adds a 5-cycle(10 in the case of Ephedrine) minimum for the stuns of these chemicals to kick in, as adding a very low dose to a syringe gun would provide an instant 5-second stun as well as heavy stamina damage. Also changed the stamina damage a bit for balancing purposes. Crank now does 20 Stamina damage and Meth does 35.