### PR TITLE
Replaces knockouts and knockdowns in melee combat

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1154,12 +1154,14 @@
 
 
 		switch(hit_area)
-			if("head")	//Harder to score a stun but if you do it lasts a bit longer
+			if("head")	//Causes dizzness, brain damage and forces the target to drop their items
 				if(H.stat == CONSCIOUS && armor_block < 50)
-					if(prob(I.force))
-						H.visible_message("<span class='danger'>[H] has been knocked unconscious!</span>", \
-										"<span class='userdanger'>[H] has been knocked unconscious!</span>")
-						H.apply_effect(20, PARALYZE, armor_block)
+					if(prob(min(I.force, 25)))
+						H.visible_message("<span class='danger'>[H] has received a concussion!</span>", \
+										"<span class='userdanger'>[H] has received a concussion!</span>")
+						H.confused += 10
+						H.apply_effect(0.5, WEAKEN, armor_block)
+						H.adjustBrainLoss(max(10, I.force/2))
 					var/role = lowertext(user.mind.special_role)
 					if(role != "revolutionary" && role != "head revolutionary")
 						if(prob(I.force + ((100 - H.health)/2)) && H != user && I.damtype == BRUTE)
@@ -1180,11 +1182,12 @@
 						H.glasses.add_blood(H)
 						H.update_inv_glasses()
 
-			if("chest")	//Easier to score a stun but lasts less time
-				if(H.stat == CONSCIOUS && I.force && prob(I.force + 10))
-					H.visible_message("<span class='danger'>[H] has been knocked down!</span>", \
-									"<span class='userdanger'>[H] has been knocked down!</span>")
-					H.apply_effect(5, WEAKEN, armor_block)
+			if("chest")	//Causes weakness and forces the target to drop their items
+				if(H.stat == CONSCIOUS && I.force && prob(min(I.force, 35)))
+					H.visible_message("<span class='danger'>[H] recoils and stumbles from the attack!</span>", \
+									"<span class='userdanger'>[H] recoils and stumbles from the attack!</span>")
+					H.apply_effect(0.5, WEAKEN, armor_block)
+					H.adjustStaminaLoss(20)
 
 				if(bloody)
 					if(H.wear_suit)

--- a/html/changelogs/Kierany9 - Melee Combat Balance.yml
+++ b/html/changelogs/Kierany9 - Melee Combat Balance.yml
@@ -1,0 +1,14 @@
+author: Kierany9
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Knockouts when aiming for the head in melee combat has been replaced with concussions. These cause a brief knockdown, dizzyness and brain damage."
+  - tweak: "Knockdowns when aiming for the body have had their duration drastically reduced but deal decent stamina damage."
+  - tweak: "Knockdown and knockout chance is capped at 35% and 25% respectively, and the bonus chance when aiming for the chest has been removed."


### PR DESCRIPTION
I've made this PR because apparently somebody thought it was a good idea to add an instant-win RNG to melee fights. If you don't know, there is a chance equal to the brute damage of the weapon used to KO the target for 20 seconds when aiming for the head, or knocking them down for five seconds when aiming for the body. Both of these pretty much guarantee a victory in a fight and are completely random.

Knockouts when aiming for the head have been replaced with concussions, which deal a very brief (0.5 second) stun, brain damage based on weapon strength and cause 10 seconds of dizzyness, which causes erratic movement, making it harder for you to run or to fight but not impossible ~~like the fucking bullshit 20 second knockout dear god fuck you cultist i was fully auged how did you fucking knock me out in one hit with that gay ass blade.~~

Knockdowns when aiming for the body have had their stun reduced from 5 seconds to 0.5 seconds but deal 20 stamina damage, once again making it harder to run.

The chances of these happening are still directly tied to the weapon damage but are capped at 25% and 35% repsectively, and knockdowns have no bonus chance of happening like they used to.