### PR TITLE
Making Codewords Useable

### DIFF
--- a/code/__HELPERS/names.dm
+++ b/code/__HELPERS/names.dm
@@ -174,9 +174,9 @@ var/syndicate_code_response//Code response for traitors.
 	)
 
 	var/safety[] = list(1,2,3)//Tells the proc which options to remove later on.
-	var/nouns[] = list("love","hate","anger","peace","pride","sympathy","bravery","loyalty","honesty","integrity","compassion","charity","success","courage","deceit","skill","beauty","brilliance","pain","misery","beliefs","dreams","justice","truth","faith","liberty","knowledge","thought","information","culture","trust","dedication","progress","education","hospitality","leisure","trouble","friendships", "relaxation")
-	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepksy Smash","tequila sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
-	var/locations[] = teleportlocs.len ? teleportlocs : drinks//if null, defaults to drinks instead.
+	var/nouns[] = list("nuke ops","cult","revs","lings","help","sec","shitcurity","lube","honk","greytide","alliums","xenos","the disk","all-access","emag","valid","cat","Ian","robust","salty","rogue","malf","convert","flash","runes","banana","soap","powergaming","shot","meth","chems","tased","search")
+	var/jobs[] = list("engineer","atmos tech","CE","doctor","chemist","viro","geneticist","CMO","scientist","roboticist","RD","assistant","bartender","chef","botanist","clown","mime","cargo tech","QM","HOP","detective","warden","HOS","captain","borgs","ai")
+	var/locations[] = list("maint","medbay","bar","tcomms","engineering","atmos","toilets","kitchen","botany","solars","derelict","perma","brig","toxins","xenobio","chapel","dorms","bridge","hop","cargo","genetics","virology","robotics","mining")
 
 	var/names[] = list()
 	for(var/datum/data/record/t in data_core.general)//Picks from crew manifest.
@@ -195,7 +195,7 @@ var/syndicate_code_response//Code response for traitors.
 			if(1)//1 and 2 can only be selected once each to prevent more than two specific names/places/etc.
 				switch(rand(1,2))//Mainly to add more options later.
 					if(1)
-						if(names.len&&prob(70))
+						if(names.len)
 							code_phrase += pick(names)
 						else
 							if(prob(10))
@@ -205,23 +205,18 @@ var/syndicate_code_response//Code response for traitors.
 								code_phrase += " "
 								code_phrase += pick(last_names)
 					if(2)
-						code_phrase += pick(get_all_jobs())//Returns a job.
+						code_phrase += pick(jobs)
 				safety -= 1
 			if(2)
 				switch(rand(1,2))//Places or things.
 					if(1)
-						code_phrase += pick(drinks)
+						code_phrase += pick(jobs)
 					if(2)
 						code_phrase += pick(locations)
 				safety -= 2
 			if(3)
-				switch(rand(1,3))//Nouns, adjectives, verbs. Can be selected more than once.
-					if(1)
-						code_phrase += pick(nouns)
-					if(2)
-						code_phrase += pick(adjectives)
-					if(3)
-						code_phrase += pick(verbs)
+				code_phrase += pick(nouns)
+
 		if(words==1)
 			code_phrase += "."
 		else

--- a/html/Kierany9 - Codewords.yml
+++ b/html/Kierany9 - Codewords.yml
@@ -1,0 +1,37 @@
+ +
++################################
++# Example Changelog File
++#
++# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
++#
++# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
++# When it is, any changes listed below will disappear.
++#
++# Valid Prefixes: 
++#   bugfix
++#   wip (For works in progress)
++#   tweak
++#   soundadd
++#   sounddel
++#   rscadd (general adding of nice things)
++#   rscdel (general deleting of nice things)
++#   imageadd
++#   imagedel
++#   spellcheck (typo fixes)
++#   experiment
++#   tgs (TG-ported fixes?)
++#################################
++
++# Your name.  
++author: N3X15
++
++# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
++delete-after: True
++
++# Any changes you've made.  See valid prefix list above.
++# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
++# SCREW THIS UP AND IT WON'T WORK.
++# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
++# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
++changes: 
++  - rscadd: "Reworked codewords! All useless words apt for a more serious server have been removed and replaced with common Hippie lingo that can blend into casual conversation and radio chatter."

--- a/html/Kierany9 - Codewords.yml
+++ b/html/Kierany9 - Codewords.yml
@@ -1,37 +1,5 @@
- +
-+################################
-+# Example Changelog File
-+#
-+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
-+#
-+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
-+# When it is, any changes listed below will disappear.
-+#
-+# Valid Prefixes: 
-+#   bugfix
-+#   wip (For works in progress)
-+#   tweak
-+#   soundadd
-+#   sounddel
-+#   rscadd (general adding of nice things)
-+#   rscdel (general deleting of nice things)
-+#   imageadd
-+#   imagedel
-+#   spellcheck (typo fixes)
-+#   experiment
-+#   tgs (TG-ported fixes?)
-+#################################
-+
-+# Your name.  
-+author: N3X15
-+
-+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
-+delete-after: True
-+
-+# Any changes you've made.  See valid prefix list above.
-+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
-+# SCREW THIS UP AND IT WON'T WORK.
-+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
-+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
-+changes: 
-+  - rscadd: "Reworked codewords! All useless words apt for a more serious server have been removed and replaced with common Hippie lingo that can blend into casual conversation and radio chatter."
+
+author: Kierany9
+delete-after: True
+changes: 
+  - rscadd: "Reworked codewords! All useless words apt for a more serious server have been removed and replaced with common Hippie lingo that can blend into casual conversation and radio chatter."


### PR DESCRIPTION
Codewords are pretty fucking useless. But they don't have to be. The only reason why they're so bad is because they use extremely specific words designed with HRP-style rounds in mind and stick out like a sore thumb here on Hippie. This PR simply changes all the available codewords for a vocabulary that is more in-tune with our server. So keep an ear out, tator-tots, we've got some new codewords coming in!

- Replaces words such as "courageous", "pride" and "loyalty" with more common ones such as "valid", "xenos" and "honk"
- Added gamemode names (nuke ops, cult, revs, lings) as uncommon codewords to give Security a push in the wrong direction
- Drinks have been removed as possible codewords
- Added a properly abbreviated list of locations (No more "Aft Solars Maintinence" thank god)
- Did the same for jobs
- Removed the small chance of it creating a random name as a codeword instead of picking one from the crew manifest