### PR TITLE
Pickpocket Gloves Traitor Item

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -814,6 +814,12 @@ var/list/uplink_items = list()
 	In addition, they can be forged to display a new assignment and name. This can be done an unlimited amount of times. Some Syndicate areas can only be accessed with these cards."
 	item = /obj/item/weapon/card/id/syndicate
 	cost = 2
+	
+/datum/uplink_item/stealthy_tools/pickpocket_gloves
+	name = "Pickpocket Gloves"
+	desc = "Gloves that allow you to quickly and stealthily remove items from people and puts them straight into your hands."
+	item = /obj/item/clothing/gloves/pickpocket
+	cost = 3
 
 /datum/uplink_item/stealthy_tools/voice_changer
 	name = "Voice Changer"

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -819,7 +819,7 @@ var/list/uplink_items = list()
 	name = "Pickpocket Gloves"
 	desc = "Gloves that allow you to quickly and stealthily remove items from people and puts them straight into your hands."
 	item = /obj/item/clothing/gloves/pickpocket
-	cost = 3
+	cost = 4
 
 /datum/uplink_item/stealthy_tools/voice_changer
 	name = "Voice Changer"

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -36,3 +36,10 @@
 	heat_protection = HANDS
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	burn_state = -1 //Won't burn in fires
+	
+/obj/item/clothing/gloves/pickpocket
+	name = "black gloves"
+	desc = "A pair of gloves, they make you feel sneaky for whatever reason."
+	icon_state = "black"
+	item_state = "bgloves"
+	item_color = null

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -389,7 +389,7 @@
 				if(pocket_item)
 					if(pocket_item == (pocket_id == slot_r_store ? r_store : l_store)) //item still in the pocket we search
 						unEquip(pocket_item)
-						if(has_pickpocket == 1)
+						if(has_pickpocket)
 							var/mob/living/carbon/human/H = usr
 							if(H.hand) //left active hand
 								H.equip_to_slot_if_possible(pocket_item, slot_l_hand, 0, 1)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -369,40 +369,43 @@
 			var/obj/item/pocket_item = (pocket_id == slot_r_store ? r_store : l_store)
 			var/obj/item/place_item = usr.get_active_hand() // Item to place in the pocket, if it's empty
 			var/delay_denominator = 1
+			var/has_pickpocket = 0
 			if(ishuman(usr))
 				var/mob/living/carbon/human/H = usr
 				if(H.gloves && istype(H.gloves,/obj/item/clothing/gloves/pickpocket))
+					has_pickpocket = 1
 					delay_denominator = 3
-				if(pocket_item && !(pocket_item.flags&ABSTRACT))
-					if(pocket_item.flags & NODROP)
-						usr << "<span class='warning'>You try to empty [src]'s [pocket_side] pocket, it seems to be stuck!</span>"
-					usr << "<span class='notice'>You try to empty [src]'s [pocket_side] pocket.</span>"
-				else if(place_item && place_item.mob_can_equip(src, pocket_id, 1) && !(place_item.flags&ABSTRACT))
-					usr << "<span class='notice'>You try to place [place_item] into [src]'s [pocket_side] pocket.</span>"
-					delay_denominator = 4
-				else
-					return
+			if(pocket_item && !(pocket_item.flags&ABSTRACT))
+				if(pocket_item.flags & NODROP)
+					usr << "<span class='warning'>You try to empty [src]'s [pocket_side] pocket, it seems to be stuck!</span>"
+				usr << "<span class='notice'>You try to empty [src]'s [pocket_side] pocket.</span>"
+			else if(place_item && place_item.mob_can_equip(src, pocket_id, 1) && !(place_item.flags&ABSTRACT))
+				usr << "<span class='notice'>You try to place [place_item] into [src]'s [pocket_side] pocket.</span>"
+				delay_denominator = 4
+			else
+				return
 
-				if(do_mob(usr, src, POCKET_STRIP_DELAY/delay_denominator)) //placing an item into the pocket is 4 times faster
-					if(pocket_item)
-						if(pocket_item == (pocket_id == slot_r_store ? r_store : l_store)) //item still in the pocket we search
-							unEquip(pocket_item)
-							if(H.gloves && istype(H.gloves,/obj/item/clothing/gloves/pickpocket))
-								if(H.hand) //left active hand
-									H.equip_to_slot_if_possible(pocket_item, slot_l_hand, 0, 1)
-								else
-									H.equip_to_slot_if_possible(pocket_item, slot_r_hand, 0, 1)
-					else
-						if(place_item)
-							usr.unEquip(place_item)
-							equip_to_slot_if_possible(place_item, pocket_id, 0, 1)
+			if(do_mob(usr, src, POCKET_STRIP_DELAY/delay_denominator)) //placing an item into the pocket is 4 times faster
+				if(pocket_item)
+					if(pocket_item == (pocket_id == slot_r_store ? r_store : l_store)) //item still in the pocket we search
+						unEquip(pocket_item)
+						if(has_pickpocket == 1)
+							var/mob/living/carbon/human/H = usr
+							if(H.hand) //left active hand
+								H.equip_to_slot_if_possible(pocket_item, slot_l_hand, 0, 1)
+							else
+								H.equip_to_slot_if_possible(pocket_item, slot_r_hand, 0, 1)
+				else
+					if(place_item)
+						usr.unEquip(place_item)
+						equip_to_slot_if_possible(place_item, pocket_id, 0, 1)
 
 					// Update strip window
 					if(usr.machine == src && in_range(src, usr))
 						show_inv(usr)
-				else
-					// Display a warning if the user mocks up
-					src << "<span class='warning'>You feel your [pocket_side] pocket being fumbled with!</span>"
+					else
+						// Display a warning if the user mocks up
+						src << "<span class='warning'>You feel your [pocket_side] pocket being fumbled with!</span>"
 
 		..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -368,33 +368,41 @@
 			var/pocket_id = (pocket_side == "right" ? slot_r_store : slot_l_store)
 			var/obj/item/pocket_item = (pocket_id == slot_r_store ? r_store : l_store)
 			var/obj/item/place_item = usr.get_active_hand() // Item to place in the pocket, if it's empty
-
 			var/delay_denominator = 1
-			if(pocket_item && !(pocket_item.flags&ABSTRACT))
-				if(pocket_item.flags & NODROP)
-					usr << "<span class='warning'>You try to empty [src]'s [pocket_side] pocket, it seems to be stuck!</span>"
-				usr << "<span class='notice'>You try to empty [src]'s [pocket_side] pocket.</span>"
-			else if(place_item && place_item.mob_can_equip(src, pocket_id, 1) && !(place_item.flags&ABSTRACT))
-				usr << "<span class='notice'>You try to place [place_item] into [src]'s [pocket_side] pocket.</span>"
-				delay_denominator = 4
-			else
-				return
-
-			if(do_mob(usr, src, POCKET_STRIP_DELAY/delay_denominator)) //placing an item into the pocket is 4 times faster
-				if(pocket_item)
-					if(pocket_item == (pocket_id == slot_r_store ? r_store : l_store)) //item still in the pocket we search
-						unEquip(pocket_item)
+			if(ishuman(usr))
+				var/mob/living/carbon/human/H = usr
+				if(H.gloves && istype(H.gloves,/obj/item/clothing/gloves/pickpocket))
+					delay_denominator = 3
+				if(pocket_item && !(pocket_item.flags&ABSTRACT))
+					if(pocket_item.flags & NODROP)
+						usr << "<span class='warning'>You try to empty [src]'s [pocket_side] pocket, it seems to be stuck!</span>"
+					usr << "<span class='notice'>You try to empty [src]'s [pocket_side] pocket.</span>"
+				else if(place_item && place_item.mob_can_equip(src, pocket_id, 1) && !(place_item.flags&ABSTRACT))
+					usr << "<span class='notice'>You try to place [place_item] into [src]'s [pocket_side] pocket.</span>"
+					delay_denominator = 4
 				else
-					if(place_item)
-						usr.unEquip(place_item)
-						equip_to_slot_if_possible(place_item, pocket_id, 0, 1)
+					return
 
-				// Update strip window
-				if(usr.machine == src && in_range(src, usr))
-					show_inv(usr)
-			else
-				// Display a warning if the user mocks up
-				src << "<span class='warning'>You feel your [pocket_side] pocket being fumbled with!</span>"
+				if(do_mob(usr, src, POCKET_STRIP_DELAY/delay_denominator)) //placing an item into the pocket is 4 times faster
+					if(pocket_item)
+						if(pocket_item == (pocket_id == slot_r_store ? r_store : l_store)) //item still in the pocket we search
+							unEquip(pocket_item)
+							if(H.gloves && istype(H.gloves,/obj/item/clothing/gloves/pickpocket))
+								if(H.hand) //left active hand
+									H.equip_to_slot_if_possible(pocket_item, slot_l_hand, 0, 1)
+								else
+									H.equip_to_slot_if_possible(pocket_item, slot_r_hand, 0, 1)
+					else
+						if(place_item)
+							usr.unEquip(place_item)
+							equip_to_slot_if_possible(place_item, pocket_id, 0, 1)
+
+					// Update strip window
+					if(usr.machine == src && in_range(src, usr))
+						show_inv(usr)
+				else
+					// Display a warning if the user mocks up
+					src << "<span class='warning'>You feel your [pocket_side] pocket being fumbled with!</span>"
 
 		..()
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -400,12 +400,12 @@
 						usr.unEquip(place_item)
 						equip_to_slot_if_possible(place_item, pocket_id, 0, 1)
 
-					// Update strip window
-					if(usr.machine == src && in_range(src, usr))
-						show_inv(usr)
-					else
-						// Display a warning if the user mocks up
-						src << "<span class='warning'>You feel your [pocket_side] pocket being fumbled with!</span>"
+				// Update strip window
+				if(usr.machine == src && in_range(src, usr))
+					show_inv(usr)
+				else
+					// Display a warning if the user mocks up
+					src << "<span class='warning'>You feel your [pocket_side] pocket being fumbled with!</span>"
 
 		..()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -759,12 +759,27 @@ Sorry Giacom. Please don't be mad :(
 	if(what.flags & NODROP)
 		src << "<span class='warning'>You can't remove \the [what.name], it appears to be stuck!</span>"
 		return
-	who.visible_message("<span class='danger'>[src] tries to remove [who]'s [what.name].</span>", \
-					"<span class='userdanger'>[src] tries to remove [who]'s [what.name].</span>")
+		
+	var/has_pickpocket = 0
+	var/delay_denominator = 1
+	if(ishuman(usr))
+		var/mob/living/carbon/human/H = usr
+		if(H.gloves && istype(H.gloves,/obj/item/clothing/gloves/pickpocket))
+			has_pickpocket = 1
+			delay_denominator = 3
+	if(has_pickpocket == 0)
+		who.visible_message("<span class='danger'>[src] tries to remove [who]'s [what.name].</span>", \
+						"<span class='userdanger'>[src] tries to remove [who]'s [what.name].</span>")
 	what.add_fingerprint(src)
-	if(do_mob(src, who, what.strip_delay))
+	if(do_mob(src, who, what.strip_delay/delay_denominator))
 		if(what && what == who.get_item_by_slot(where) && Adjacent(who))
 			who.unEquip(what)
+			if(has_pickpocket == 1)
+				var/mob/living/carbon/human/H = usr
+				if(H.hand) //left active hand
+					H.equip_to_slot_if_possible(what, slot_l_hand, 0, 1)
+				else
+					H.equip_to_slot_if_possible(what, slot_r_hand, 0, 1)
 			add_logs(src, who, "stripped", addition="of [what]")
 
 // The src mob is trying to place an item on someone

--- a/html/changelogs/Kierany9 - Pickpocket Gloves.yml
+++ b/html/changelogs/Kierany9 - Pickpocket Gloves.yml
@@ -1,0 +1,13 @@
+
+author: Kierany9
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added pickpocket gloves to the Traitor Uplink for 3 TC. These gloves let you remove items from people much faster and won't alert them to your theivery, as well as placing the item straight into your hand."

--- a/html/changelogs/Kierany9 - Pickpocket Gloves.yml
+++ b/html/changelogs/Kierany9 - Pickpocket Gloves.yml
@@ -10,4 +10,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added pickpocket gloves to the Traitor Uplink for 3 TC. These gloves let you remove items from people much faster and won't alert them to your theivery, as well as placing the item straight into your hand."
+  - rscadd: "Added pickpocket gloves to the Traitor Uplink for 4 TC. These gloves let you remove items from people much faster and won't alert them to your theivery, as well as placing the item straight into your hand."


### PR DESCRIPTION
Adds Pickpocket Gloves to the Traitor Uplink for ~~3~~ 4 TC. These gloves triple your stripping speed, remove any alerts the target may get to having their equipment stripped and places any stolen items straight into your hand. While this means you can only take off one item at a time since it fills your hand, by the time they notice it'll probably be too late and you got off scott-free with their ID, egun or nuke disk. Not the most powerful of items since it relies on you getting extremely close to well-armed people to get the most out of it but generally great for harassment and theft, especially when combined with soap and other slips.