### PR TITLE
Mech buffs

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -73,6 +73,10 @@
 	energy_drain = 30
 	projectile = /obj/item/projectile/beam
 	fire_sound = 'sound/weapons/Laser.ogg'
+	projectiles_per_shot = 2
+	variance = 6 //Small spread
+	randomspread = 1 //Random spread.
+	projectile_delay = 4 //1 decisecond before sending another projectile.
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy
 	equip_cooldown = 15
@@ -82,9 +86,13 @@
 	energy_drain = 60
 	projectile = /obj/item/projectile/beam/heavylaser
 	fire_sound = 'sound/weapons/lasercannonfire.ogg'
+	projectiles_per_shot = 2
+	variance = 4 //Small spread
+	randomspread = 1 //Random spread.
+	projectile_delay = 4 //1 decisecond before sending another projectile.
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/ion
-	equip_cooldown = 20
+	equip_cooldown = 15
 	name = "\improper MKIV ion heavy cannon"
 	desc = "A weapon for combat exosuits. Shoots technology-disabling ion beams. Don't catch yourself in the blast!"
 	icon_state = "mecha_ion"
@@ -101,6 +109,10 @@
 	origin_tech = "materials=3;combat=6;powerstorage=4"
 	projectile = /obj/item/projectile/beam/pulse/heavy
 	fire_sound = 'sound/weapons/marauder.ogg'
+	projectiles_per_shot = 2
+	variance = 2 //Small spread
+	randomspread = 1 //Random spread.
+	projectile_delay = 4 //1 decisecond before sending another projectile.
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma
 	equip_cooldown = 20
@@ -143,7 +155,19 @@
 	equip_cooldown = 8
 	projectile = /obj/item/projectile/energy/electrode
 	fire_sound = 'sound/weapons/Taser.ogg'
-
+	
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/disabler
+	name = "\improper RTC \"Detainer\" repeating disabler"
+	desc = "A weapon for combat exosuits. Shoots a volley of stamina-reducing disabler beams."
+	icon_state = "mecha_taser"
+	energy_drain = 60
+	equip_cooldown = 12
+	projectiles_per_shot = 3
+	variance = 2
+	randomspread = 1
+	projectile_delay = 3
+	projectile = /obj/item/projectile/beam/disabler
+	fire_sound = 'sound/weapons/taser2.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/honker
 	name = "\improper HoNkER BlAsT 5000"
@@ -257,25 +281,25 @@
 	name = "\improper LBX AC 10 \"Scattershot\""
 	desc = "A weapon for combat exosuits. Shoots a spread of pellets."
 	icon_state = "mecha_scatter"
-	equip_cooldown = 20
+	equip_cooldown = 10
 	projectile = /obj/item/projectile/bullet/midbullet
-	projectiles = 40
+	projectiles = 42
 	projectile_energy_cost = 25
-	projectiles_per_shot = 4
-	variance = 25
+	projectiles_per_shot = 6
+	variance = 20
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
 	name = "\improper Ultra AC 2"
-	desc = "A weapon for combat exosuits. Shoots a rapid, three shot burst."
+	desc = "A weapon for combat exosuits. Shoots a rapid, six shot burst."
 	icon_state = "mecha_uac2"
-	equip_cooldown = 4
-	projectile = /obj/item/projectile/bullet/weakbullet
+	equip_cooldown = 5
+	projectile = /obj/item/projectile/bullet/weakbullet4
 	projectiles = 300
 	projectile_energy_cost = 20
-	projectiles_per_shot = 3
+	projectiles_per_shot = 6
 	variance = 6 //Small spread
 	randomspread = 1 //Random spread.
-	projectile_delay = 2 //2 deciseconds before sending another projectile.
+	projectile_delay = 1 //1 decisecond before sending another projectile.
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/bulletstorm //Mostly for testing, but it's also pretty as hell.
 	name = "\improper Bulletstorm U.N.Owen-Alpha"
@@ -317,7 +341,7 @@
 	fire_sound = 'sound/weapons/grenadelauncher.ogg'
 	projectiles = 8
 	projectile_energy_cost = 1000
-	equip_cooldown = 60
+	equip_cooldown = 40
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/missile_rack/proj_init(var/obj/item/missile/M)
 	M.primed = 1

--- a/code/modules/research/designs/mecha_designs.dm
+++ b/code/modules/research/designs/mecha_designs.dm
@@ -199,14 +199,14 @@
 	construction_time = 100
 	category = list("Exosuit Equipment")
 
-/datum/design/mech_laser
-	name = "Exosuit Weapon (CH-PS \"Immolator\" Laser)"
-	desc = "Allows for the construction of CH-PS Laser."
-	id = "mech_laser"
+/datum/design/mech_lmg
+	name = "Exosuit Weapon (Ultra AC 2)"
+	desc = "Allows for the construction of Ultra AC 2 LMG."
+	id = "mech_lmg"
 	build_type = MECHFAB
-	req_tech = list("combat" = 3, "magnets" = 3)
-	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
-	materials = list(MAT_METAL=10000)
+	req_tech = list("combat" = 6)
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
+	materials = list(MAT_METAL=10000,MAT_SILVER=8000)
 	construction_time = 100
 	category = list("Exosuit Equipment")
 

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -567,11 +567,20 @@
 	construction_time = 100
 	category = list("Exosuit Equipment")
 
-/datum/design/mech_lmg
-	name = "Exosuit Weapon (\"Ultra AC 2\" LMG)"
-	id = "mech_lmg"
+/datum/design/mech_disabler
+	name = "Exosuit Weapon (RTC \"Detainer\" repeating disabler)"
+	id = "mech_disabler"
 	build_type = MECHFAB
-	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/disabler
+	materials = list(MAT_METAL=10000)
+	construction_time = 100
+	category = list("Exosuit Equipment")
+
+/datum/design/mech_laser
+	name = "Exosuit Weapon (CH-PS \"Immolator\" laser)"
+	id = "mech_laser"
+	build_type = MECHFAB
+	build_path = /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser
 	materials = list(MAT_METAL=10000)
 	construction_time = 100
 	category = list("Exosuit Equipment")

--- a/html/changelogs/Kierany9 - Mech Balance.yml
+++ b/html/changelogs/Kierany9 - Mech Balance.yml
@@ -35,4 +35,4 @@ delete-after: True
 changes: 
   - rscadd: "General Mech rebalancing: Most mech weapons are now superior in some way to their non-mounted counterparts and mech ballistics are no-longer a complete joke."
   - rscadd: "Added the RTC "Detainer" repeating disabler, a mech-mounted disabler that fires a three-shot burst, enough to keep anybody hit by it on the ground."
-  - tweak: "The CH-PS "Immolator" Laser is now the default mech weapon, the Ultra AC 2 LMG has received a significiant buff and placed behind a research."
+  - tweak: "The CH-PS "Immolator" Laser is now the default mech weapon, the Ultra AC 2 LMG has received a significiant buff and placed behind a research wall."

--- a/html/changelogs/Kierany9 - Mech Balance.yml
+++ b/html/changelogs/Kierany9 - Mech Balance.yml
@@ -34,5 +34,5 @@ delete-after: True
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
   - rscadd: "General Mech rebalancing: Most mech weapons are now superior in some way to their non-mounted counterparts and mech ballistics are no-longer a complete joke."
-  - rscadd: "Added the RTC "Detainer" repeating disabler, a mech-mounted disabler that fires a three-shot burst, enough to keep anybody hit by it on the ground."
-  - tweak: "The CH-PS "Immolator" Laser is now the default mech weapon, the Ultra AC 2 LMG has received a significiant buff and placed behind a research wall."
+  - rscadd: "Added the RTC \"Detainer\" repeating disabler, a mech-mounted disabler that fires a three-shot burst, enough to keep anybody hit by it on the ground."
+  - tweak: "The CH-PS \"Immolator\" Laser is now the default mech weapon, the Ultra AC 2 LMG has received a significiant buff and placed behind a research wall."

--- a/html/changelogs/Kierany9 - Mech Balance.yml
+++ b/html/changelogs/Kierany9 - Mech Balance.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Kierany9
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "General Mech rebalancing: Most mech weapons are now superior in some way to their non-mounted counterparts and mech ballistics are no-longer a complete joke."
+  - rscadd: "Added the RTC "Detainer" repeating disabler, a mech-mounted disabler that fires a three-shot burst, enough to keep anybody hit by it on the ground."
+  - tweak: "The CH-PS "Immolator" Laser is now the default mech weapon, the Ultra AC 2 LMG has received a significiant buff and placed behind a research."


### PR DESCRIPTION
You wanna know how much damage the mech LMG does? A light machine gun that's mounted on a war robot designed to kill you as efficiently as possible while tanking a metric fuckton of damage?

Five

Yep, five.

**FIVE!!!**

Anyway, this PR basically buffs some of the mech weapons to stop them from being a laughing stock and make them actually worth using, most notably the Incendinary Carbine AKA Hades(Now fires incendinary slugs instead of a single dragonsbreath pellet, increasing its damage from 5 to 20), the LMG AKA Ultra AC 2(Fires a 6-shot burst with bullets dealing 10 damage each instead of a 3-shot burst of 5 damage 80 stamina bullets), the Shotgun AKA Scattershot(Increased pellets fired from 4 to 6 and tightened the spread slightly for maximum hallway devastation) and the laser and pulse cannons AKA Immolator, Solaris and eZ-13(Fires a two-shot burst instead of a single shot).

The Immolator is no-longer behind a research wall, but the Ultra AC 2 now is. Nanotrasen tends to prefer lasers whereas the Syndicate mostly use ballistics, it didn't make sense to have the LMG(which is weaker than a fucking uzi mind you) as a starting weapon and have the laser behind a research wall.

Adds a mech disabler, the RTC Detainer. Is available from the get-go and fires a three-shot burst of disablers which is enough to knock somebody out.

This update was mostly done to make the Dark Gygax and Dark Marauder actually useful, because as it stands their main weapons are an absolute joke, combine this with the subpar defenses of the Gygax or the absolute piss-poor mobility of the Marauder and both of their incredible vulnerabilities to the Ion Rifle and you have an absolute waste of 140 TC.