### PR TITLE
Adds admin logs anytime a non observing admin ghosts or views the player panel

### DIFF
--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -68,6 +68,9 @@
 						entry += " - <font color='black'><b>DEAD</b></font>"
 				else
 					entry += " - <font color='black'><b>DEAD</b></font>"
+		if(is_special_character(C.mob))
+			entry += " - <b><font color='red'>Antagonist</font></b>"
+	entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
 	return entry
 
 /client/verb/adminwho()

--- a/code/game/verbs/who.dm
+++ b/code/game/verbs/who.dm
@@ -68,9 +68,6 @@
 						entry += " - <font color='black'><b>DEAD</b></font>"
 				else
 					entry += " - <font color='black'><b>DEAD</b></font>"
-		if(is_special_character(C.mob))
-			entry += " - <b><font color='red'>Antagonist</font></b>"
-	entry += " (<A HREF='?_src_=holder;adminmoreinfo=\ref[C.mob]'>?</A>)"
 	return entry
 
 /client/verb/adminwho()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -169,6 +169,7 @@ var/global/floorIsLava = 0
 	body += "</body></html>"
 
 	usr << browse(body, "window=adminplayeropts-\ref[M];size=550x515")
+	message_admins("[key_name_admin(usr)] has shown the player panel of [M].")
 	feedback_add_details("admin_verb","SPP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -170,7 +170,7 @@ var/global/floorIsLava = 0
 
 	usr << browse(body, "window=adminplayeropts-\ref[M];size=550x515")
 	if(!isobserver(usr))
-		message_admins("[key_name_admin(usr)] has shown the player panel of [M].")
+		log_admin("[key_name_admin(usr)] has shown the player panel of [M].")
 	feedback_add_details("admin_verb","SPP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -169,7 +169,8 @@ var/global/floorIsLava = 0
 	body += "</body></html>"
 
 	usr << browse(body, "window=adminplayeropts-\ref[M];size=550x515")
-	message_admins("[key_name_admin(usr)] has shown the player panel of [M].")
+	if(!isobserver(usr))
+		message_admins("[key_name_admin(usr)] has shown the player panel of [M].")
 	feedback_add_details("admin_verb","SPP") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -364,7 +364,7 @@ var/list/admin_verbs_hideable = list(
 	if(holder)
 		holder.player_panel_new()
 		if(!isobserver(usr))
-			message_admins("[key_name_admin(usr)] has opened the player panel.")
+			log_admin("[key_name_admin(usr)] has opened the player panel.")
 	feedback_add_details("admin_verb","PPN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 
@@ -374,6 +374,8 @@ var/list/admin_verbs_hideable = list(
 	if(holder)
 		holder.check_antagonists()
 		log_admin("[key_name(usr)] checked antagonists.")	//for tsar~
+		if(!isobserver(usr))
+			message_admins("[key_name_admin(usr)] checked antagonists.")
 	feedback_add_details("admin_verb","CHA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -341,7 +341,8 @@ var/list/admin_verbs_hideable = list(
 		body.ghostize(1)
 		if(body && !body.key)
 			body.key = "@[key]"	//Haaaaaaaack. But the people have spoken. If it breaks; blame adminbus
-			message_admins("[key_name_admin(usr)] has admin ghosted.")
+			if(!isobserver(usr))
+				message_admins("[key_name_admin(usr)] has admin ghosted.")
 		feedback_add_details("admin_verb","O") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
@@ -362,7 +363,8 @@ var/list/admin_verbs_hideable = list(
 	set category = "Admin"
 	if(holder)
 		holder.player_panel_new()
-		message_admins("[key_name_admin(usr)] has opened the player panel.")
+		if(!isobserver(usr))
+			message_admins("[key_name_admin(usr)] has opened the player panel.")
 	feedback_add_details("admin_verb","PPN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -342,7 +342,7 @@ var/list/admin_verbs_hideable = list(
 		if(body && !body.key)
 			body.key = "@[key]"	//Haaaaaaaack. But the people have spoken. If it breaks; blame adminbus
 			if(!isobserver(usr))
-				message_admins("[key_name_admin(usr)] has admin ghosted.")
+				log_admin("[key_name_admin(usr)] has admin ghosted.")
 		feedback_add_details("admin_verb","O") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
@@ -374,8 +374,6 @@ var/list/admin_verbs_hideable = list(
 	if(holder)
 		holder.check_antagonists()
 		log_admin("[key_name(usr)] checked antagonists.")	//for tsar~
-		if(!isobserver(usr))
-			message_admins("[key_name_admin(usr)] checked antagonists.")
 	feedback_add_details("admin_verb","CHA") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -341,6 +341,7 @@ var/list/admin_verbs_hideable = list(
 		body.ghostize(1)
 		if(body && !body.key)
 			body.key = "@[key]"	//Haaaaaaaack. But the people have spoken. If it breaks; blame adminbus
+			message_admins("[key_name_admin(usr)] has admin ghosted.")
 		feedback_add_details("admin_verb","O") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 
@@ -361,6 +362,7 @@ var/list/admin_verbs_hideable = list(
 	set category = "Admin"
 	if(holder)
 		holder.player_panel_new()
+		message_admins("[key_name_admin(usr)] has opened the player panel.")
 	feedback_add_details("admin_verb","PPN") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 	return
 


### PR DESCRIPTION
Admins can ghost and see a shit ton of round information and it's not even logged. It's very easy to get away with. In the same vein, an Admin can open the player panel, hover over someone's name and see if they are a traitor or not, absolutely no way to get caught. This fixes it, so if a non observing admin ghosts, opens the player panel, or shows the player panel of a specific player, other admins are notified.  That's all.