### PR TITLE
Lings cannot use gateways

### DIFF
--- a/code/modules/awaymissions/gateway.dm
+++ b/code/modules/awaymissions/gateway.dm
@@ -141,6 +141,11 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 		return
 	if(!active)
 		return
+	if(ismob(AM))
+		var/mob/M = AM
+		if(M.mind && M.mind.changeling)
+			M << "The ancient builders of this gate seem to have barred our kind from using their technology..."
+			return
 	if(!awaygate || qdeleted(awaygate))
 		return
 
@@ -252,6 +257,11 @@ var/obj/machinery/gateway/centerstation/the_gateway = null
 		return
 	if(!active)
 		return
+	if(ismob(AM))
+		var/mob/M = AM
+		if(M.mind && M.mind.changeling)
+			M << "The ancient builders of this gate seem to have barred our kind from using their technology..."
+			return
 	if(!stationgate || qdeleted(stationgate))
 		return
 	if(istype(AM, /mob/living/carbon))


### PR DESCRIPTION
This was in another PR with mixed to unfavorable opinions. I could remove the ability for this to be used as a ling test by: 

*Lings lose their changeling powers when in the gateway, period, or at least, remove their ability to do anything except regenerate 

However, in response to that, I just think that a ling's abilities, such as adrenaline surge, combined with the loot they can get is the problem. It's not a matter of them clearing the away mission or getting free guns, the problem is when they come back to the station, they are a changeling, an already formidable foe, with access to things such as demon hearts, and deathsquad armor, and assault rifles.

*Have the teleportation be done by clicking on the gate, turning the portal off or on is done by a panel or button.

If you are a headmin, and vote no on this PR, please also tell me if you want one of those other options added.


___

