### PR TITLE
Removes artificial lag on AI tracking

### DIFF
--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -91,11 +91,6 @@
 	U.cameraFollow = target
 	U.tracking = 1
 
-	U << "<span class='notice'>Attempting to track [target.get_visible_name()]...</span>"
-	sleep(min(30, get_dist(target, U.eyeobj) / 4))
-	spawn(15) //give the AI a grace period to stop moving.
-		U.tracking = 0
-
 	if(!target || !target.can_track(usr))
 		U << "<span class='warning'>Target is not near any active cameras.</span>"
 		U.cameraFollow = null


### PR DESCRIPTION
Ported over from /tg/. Some faggot a long time ago added artificial lag on the AI camera tracking. /tg/ removed it there a few months ago, and now I'm removing it here.