### PR TITLE
Balances Shadowlings

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -273,8 +273,9 @@ Made by Xhuis
 			H.adjustToxLoss(-5)
 			H.adjustBrainLoss(-25) //Shad O. Ling gibbers, "CAN U BE MY THRALL?!!"
 			H.adjustCloneLoss(-1)
-			H.SetWeakened(0)
-			H.SetStunned(0)
+			H.AdjustParalysis(-2)
+			H.AdjustStunned(-2)
+			H.AdjustWeakened(-2)
 
 /datum/species/shadow/ling/lesser //Empowered thralls. Obvious, but powerful
 	name = "Lesser Shadowling"

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -1,4 +1,5 @@
 #define EMPOWERED_THRALL_LIMIT 5
+var/in_jaunt = 0
 
 /obj/effect/proc_holder/spell/proc/shadowling_check(var/mob/living/carbon/human/H)
 	if(!H || !istype(H)) return
@@ -34,6 +35,9 @@
 			return
 		if(is_shadow_or_thrall(target))
 			user << "<span class='warning'>You cannot glare at allies!</span>"
+			revert_cast()
+			return
+		if (in_jaunt)
 			revert_cast()
 			return
 		var/mob/living/carbon/human/M = target
@@ -110,7 +114,7 @@
 	name = "Shadow Walk"
 	desc = "Phases you into the space between worlds for a short time, allowing movement through walls and invisbility."
 	panel = "Shadowling Abilities"
-	charge_max = 300 //Used to be twice this, buffed
+	charge_max = 450
 	human_req = 1
 	clothes_req = 0
 	action_icon_state = "shadow_walk"
@@ -120,18 +124,20 @@
 	if(!shadowling_check(user))
 		revert_cast()
 		return
+	if(usr.stunned)
+		revert_cast()
+		return
 	user.visible_message("<span class='warning'>[user] vanishes in a puff of black mist!</span>", "<span class='shadowling'>You enter the space between worlds as a tunnel.</span>")
-	user.SetStunned(0)
-	user.SetWeakened(0)
 	user.incorporeal_move = 1
 	user.alpha = 0
 	if(user.buckled)
 		user.buckled.unbuckle_mob()
+	in_jaunt = 1
 	sleep(40) //4 seconds
 	user.visible_message("<span class='warning'>[user] suddenly manifests!</span>", "<span class='shadowling'>The rift's pressure forces you back to corporeality.</span>")
 	user.incorporeal_move = 0
 	user.alpha = 255
-
+	in_jaunt = 0
 
 /obj/effect/proc_holder/spell/aoe_turf/flashfreeze //Stuns and freezes nearby people - a bit more effective than a changeling's cryosting
 	name = "Icy Veins"
@@ -324,7 +330,7 @@
 		revert_cast()
 		return
 	var/thralls = 0
-	var/victory_threshold = 15
+	var/victory_threshold = 20
 	var/mob/M
 
 	user << "<span class='shadowling'><b>You focus your telepathic energies abound, harnessing and drawing together the strength of your thralls.</b></span>"
@@ -608,6 +614,7 @@ datum/reagent/shadowling_blindness_smoke //Reagent used for above spell
 				return
 
 
+/*
 /obj/effect/proc_holder/spell/targeted/shadowling_extend_shuttle
 	name = "Destroy Engines"
 	desc = "Extends the time of the emergency shuttle's arrival by fifteen minutes. This can only be used once."
@@ -655,6 +662,8 @@ datum/reagent/shadowling_blindness_smoke //Reagent used for above spell
 			SSshuttle.emergency.setTimer(timer)
 		user.mind.spell_list.Remove(src) //Can only be used once!
 		qdel(src)
+		
+		*/
 
 
 // THRALL ABILITIES BEYOND THIS POINT //

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -1,5 +1,4 @@
 #define EMPOWERED_THRALL_LIMIT 5
-var/in_jaunt = 0
 
 /obj/effect/proc_holder/spell/proc/shadowling_check(var/mob/living/carbon/human/H)
 	if(!H || !istype(H)) return
@@ -8,7 +7,12 @@ var/in_jaunt = 0
 	if(!is_shadow_or_thrall(usr)) usr << "<span class='warning'>You can't wrap your head around how to do this.</span>"
 	else if(is_thrall(usr)) usr << "<span class='warning'>You aren't powerful enough to do this.</span>"
 	else if(is_shadow(usr)) usr << "<span class='warning'>Your telepathic ability is suppressed. Hatch or use Rapid Re-Hatch first.</span>"
-	return 0
+
+/obj/effect/proc_holder/spell/proc/jaunt_check(var/mob/living/carbon/human/H)
+	if(H.incorporeal_move == 1)
+		return 1
+	else
+		return 0
 
 
 /obj/effect/proc_holder/spell/targeted/glare //Stuns and mutes a human target for 10 seconds
@@ -29,15 +33,16 @@ var/in_jaunt = 0
 		if(!shadowling_check(user))
 			revert_cast()
 			return
+		if(jaunt_check(user))
+			revert_cast()
+			usr << "<span class='warning'>You can't use this spell in the space between dimensions!</span>"
+			return
 		if(target.stat)
 			user << "<span class='warning'>[target] must be conscious!</span>"
 			revert_cast()
 			return
 		if(is_shadow_or_thrall(target))
 			user << "<span class='warning'>You cannot glare at allies!</span>"
-			revert_cast()
-			return
-		if (in_jaunt)
 			revert_cast()
 			return
 		var/mob/living/carbon/human/M = target
@@ -132,13 +137,11 @@ var/in_jaunt = 0
 	user.alpha = 0
 	if(user.buckled)
 		user.buckled.unbuckle_mob()
-	in_jaunt = 1
 	sleep(40) //4 seconds
 	user.visible_message("<span class='warning'>[user] suddenly manifests!</span>", "<span class='shadowling'>The rift's pressure forces you back to corporeality.</span>")
 	user.incorporeal_move = 0
 	user.alpha = 255
-	in_jaunt = 0
-
+	
 /obj/effect/proc_holder/spell/aoe_turf/flashfreeze //Stuns and freezes nearby people - a bit more effective than a changeling's cryosting
 	name = "Icy Veins"
 	desc = "Instantly freezes the blood of nearby people, stunning them and causing burn damage."
@@ -153,6 +156,10 @@ var/in_jaunt = 0
 /obj/effect/proc_holder/spell/aoe_turf/flashfreeze/cast(list/targets,mob/user = usr)
 	if(!shadowling_check(user))
 		revert_cast()
+		return
+	if(jaunt_check(user))
+		revert_cast()
+		usr << "<span class='warning'>You can't use this spell in the space between dimensions!</span>"
 		return
 	user << "<span class='shadowling'>You freeze the nearby air.</span>"
 	for(var/turf/T in targets)
@@ -452,6 +459,10 @@ datum/reagent/shadowling_blindness_smoke //Reagent used for above spell
 /obj/effect/proc_holder/spell/aoe_turf/unearthly_screech/cast(list/targets,mob/user = usr)
 	if(!shadowling_check(user))
 		revert_cast()
+		return
+	if(jaunt_check(user))
+		revert_cast()
+		usr << "<span class='warning'>You can't use this spell in the space between dimensions!</span>"
 		return
 	user.audible_message("<span class='warning'><b>[user] lets out a horrible scream!</b></span>")
 	for(var/turf/T in targets)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -7,6 +7,7 @@
 	if(!is_shadow_or_thrall(usr)) usr << "<span class='warning'>You can't wrap your head around how to do this.</span>"
 	else if(is_thrall(usr)) usr << "<span class='warning'>You aren't powerful enough to do this.</span>"
 	else if(is_shadow(usr)) usr << "<span class='warning'>Your telepathic ability is suppressed. Hatch or use Rapid Re-Hatch first.</span>"
+	return 0
 
 /obj/effect/proc_holder/spell/proc/jaunt_check(var/mob/living/carbon/human/H)
 	if(H.incorporeal_move == 1)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -330,7 +330,7 @@ var/in_jaunt = 0
 		revert_cast()
 		return
 	var/thralls = 0
-	var/victory_threshold = 20
+	var/victory_threshold = 15
 	var/mob/M
 
 	user << "<span class='shadowling'><b>You focus your telepathic energies abound, harnessing and drawing together the strength of your thralls.</b></span>"

--- a/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/special_shadowling_abilities.dm
@@ -97,7 +97,7 @@ var/list/possibleShadowlingNames = list("U'ruan", "Y`shej", "Nex", "userel-uae",
 			user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/flashfreeze(null))
 			user.mind.AddSpell(new /obj/effect/proc_holder/spell/self/collective_mind(null))
 			user.mind.AddSpell(new /obj/effect/proc_holder/spell/self/shadowling_regenarmor(null))
-			user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_extend_shuttle(null))
+			//user.mind.AddSpell(new /obj/effect/proc_holder/spell/targeted/shadowling_extend_shuttle(null))
 
 
 

--- a/html/changelogs/Logos - Shadowling.yml
+++ b/html/changelogs/Logos - Shadowling.yml
@@ -6,6 +6,5 @@ changes:
   - tweak: "Shadow Walk cooldown time increased to 45 seconds."
   - tweak: "You can no longer use Shadow Walk after being stunned, you have to wait till the stun wears off to use it."
   - tweak: "You can no longer use certain shadowling abilities while in Shadow Walk."
-  - tweak: "Thralls needed to ascend increased from 15 to 20."
   - tweak: "Shadowlings no longer are stun immune while in the dark, instead they just have their stuns reduced."
   - rscdel: "Shadowlings can no longer use the spell Destroy Engines."

--- a/html/changelogs/Logos - Shadowling.yml
+++ b/html/changelogs/Logos - Shadowling.yml
@@ -1,0 +1,11 @@
+author: Logos
+
+delete-after: True
+
+changes:
+  - tweak: "Shadow Walk cooldown time increased to 45 seconds."
+  - tweak: "You can no longer use Shadow Walk after being stunned, you have to wait till the stun wears off to use it."
+  - tweak: "You can no longer use certain shadowling abilities while in Shadow Walk."
+  - tweak: "Thralls needed to ascend increased from 15 to 20."
+  - tweak: "Shadowlings no longer are stun immune while in the dark, instead they just have their stuns reduced."
+  - rscdel: "Shadowlings can no longer use the spell Destroy Engines."


### PR DESCRIPTION
Shadowlings are OP. Everyone knows it.

changes:
- tweak: "Shadow Walk cooldown time increased to 45 seconds."
- tweak: "You can no longer use Shadow Walk after being stunned, you
have to wait till the stun wears off to use it."
- tweak: "You can no longer use certain shadowling abilities while in
Shadow Walk."
- tweak: "Shadowlings no longer are stun immune while in the dark,
instead they just have their stuns reduced."
- rscdel: "Shadowlings can no longer use the spell Destroy Engines."