### PR TITLE
Dominator area fix

### DIFF
--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -403,6 +403,9 @@
 						return
 
 				if(usrarea.type in gang.territory|gang.territory_new)
+					if(!is_type_in_list(get_area(src), the_station_areas))
+						usr << "<span class='warning'>You can only use this on station areas!</span>"
+						return
 					if(gang.points >= 30)
 						item_type = /obj/machinery/dominator
 						usr << "<span class='notice'>The <b>dominator</b> will secure your gang's dominance over the station. Turn it on when you are ready to defend it.</span>"

--- a/html/changelogs/Spacedong - dominatorfix.yml
+++ b/html/changelogs/Spacedong - dominatorfix.yml
@@ -1,0 +1,37 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Spacedong
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixed bug where dominators could be placed on non-station/renamed areas or bluespace shelters."
+  


### PR DESCRIPTION
Fixes issue #2606 where a dominator could be placed in a bluespace shelter/another area in space. 