### PR TITLE
Fixes secure storage bullshit

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -65,11 +65,17 @@
 
 /obj/item/weapon/storage/AltClick() //Altclick is a shortcut to open the bag so you don't have to constantly drag&drop backpacks to check them w/o picking them up
 	..()
+	var/obj/item/weapon/storage/secure/S
 	var/mob/M = usr
 	if(Adjacent(M))
 		orient2hud(M)
 		if(M.s_active)
 			M.s_active.close(M)
+		if(istype(src,/obj/item/weapon/storage/secure))
+			S = src
+		if (S)
+			if (S.locked)
+				return attack_self(M)
 		show_to(M)
 
 //Check if this storage can dump the items

--- a/html/changelogs/Spacedong - securefix.yml
+++ b/html/changelogs/Spacedong - securefix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Spacedong
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Fixes secure things not actually being secure!"


### PR DESCRIPTION
Locked secure storage items are no longer able to be bypassed by alt clicking and removing the contents. Fixes issue #2597