### PR TITLE
Spirit Camera Traitor Item

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -152,6 +152,14 @@ var/list/uplink_items = list()
 	cost = 14
 	jobs = list("Botanist", "Bartender", "Chef")
 
+//CIVILIAN DIVISION
+/datum/uplink_item/job_specific/spiritcam
+	name = "Spirit Camera"
+	desc = "This special camera allows you to take long-distance photographs of any living person provided you know their name."
+	item = /obj/item/device/camera/spiritcam
+	cost = 4
+	jobs = list("Librarian", "Assistant", "Clown", "Mime", "Lawyer", "Chaplain")
+
 //LIBRARIAN
 /datum/uplink_item/job_specific/soulstone
 	name = "Soulstone"

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -460,7 +460,7 @@
 			real_living_players[M.real_name] = M
 			if(M.real_name == wanted)
 				wanted_players += M
-				wanted_players[M.real_name] = M
+				wanted_players[M] = M
 		if(wanted in real_living_players)
 			target = input(user, "Who would you like to take a photograph of?", "Target name") as null|anything in wanted_players
 			if(target.onCentcom())

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -452,14 +452,17 @@
 
 /obj/item/device/camera/spiritcam/afterattack(atom/target, mob/user, flag)
 	if(remote && on && pictures_left)
-		var/list/living_players = living_mob_list
 		var/list/real_living_players = list()
-		for(var/mob/M in living_players)
+		var/list/wanted_players = list()
+		var/wanted = copytext(sanitize(input(user, "Who would you like to take a photograph of?", "Target name")as text | null),1,26)
+		for(var/mob/M in living_mob_list)
 			real_living_players += M.real_name
 			real_living_players[M.real_name] = M
-		var/wanted = copytext(sanitize(input(user, "Who would you like to take a photograph of?", "Target name")as text | null),1,26)
+			if(M.real_name == wanted)
+				wanted_players += M
+				wanted_players[M.real_name] = M
 		if(wanted in real_living_players)
-			target = real_living_players[wanted]
+			target = input(user, "Who would you like to take a photograph of?", "Target name") as null|anything in wanted_players
 			var/turf/target_turf = get_turf(target)
 			if(target_turf.z == 2)
 				target = user

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -112,9 +112,13 @@
 	var/pictures_max = 10
 	var/pictures_left = 10
 	var/on = 1
+	var/remote = 0 //For taking pictures with the spirit camera
 	var/blueprints = 0	//are blueprints visible in the current photo being created?
 	var/list/aipictures = list() //Allows for storage of pictures taken by AI, in a similar manner the datacore stores info. Keeping this here allows us to share some procs w/ regualar camera
 
+/obj/item/device/camera/spiritcam
+	pictures_max = 4
+	pictures_left = 4
 
 /obj/item/device/camera/siliconcam //camera AI can take pictures with
 	name = "silicon photo camera"
@@ -234,7 +238,7 @@
 
 	var/list/turfs = list()
 	for(var/turf/T in range(1, target))
-		if(T in seen)
+		if((T in seen) || remote)
 			if(isAi && !cameranet.checkTurfVis(T))
 				continue
 			else
@@ -377,6 +381,19 @@
 		viewpichelper(Ainfo)
 
 /obj/item/device/camera/afterattack(atom/target, mob/user, flag)
+	if(remote && on && pictures_left)
+		var/list/living_players = living_mob_list
+		var/list/real_living_players = list()
+		for(var/mob/M in living_players)
+			real_living_players += M.real_name
+			real_living_players[M.real_name] = M
+		var/wanted = copytext(sanitize(input(user, "Who would you like to take a photograph of?", "Target name")as text | null),1,26)
+		if(wanted in real_living_players)
+			target = real_living_players[wanted]
+		else
+			target = user
+		if(isobj(target.loc))
+			target = target.loc
 	if(!on || !pictures_left || ismob(target.loc)) return
 	captureimage(target, user, flag)
 
@@ -386,9 +403,14 @@
 	user << "<span class='notice'>[pictures_left] photos left.</span>"
 	icon_state = "camera_off"
 	on = 0
-	spawn(64)
-		icon_state = "camera"
-		on = 1
+	if(!remote)
+		spawn(64)
+			icon_state = "camera"
+			on = 1
+	else
+		spawn(600)
+			icon_state = "camera"
+			on = 1
 
 /obj/item/device/camera/siliconcam/proc/toggle_camera_mode()
 	if(in_camera_mode)
@@ -434,3 +456,13 @@
 	C.toner -= 20	 //Cyborgs are very ineffeicient at printing an image
 	visible_message("[C.name] spits out a photograph from a narrow slot on it's chassis.")
 	usr << "<span class='notice'>You print a photograph.</span>"
+
+/obj/item/device/camera/spiritcam/attack_self(mob/user)
+	if(istype(user, /mob/living) && user.mind)
+		if(user.mind.special_role && on)
+			if(remote)
+				user << "<span class='notice'>You set the camera back to normal.</span>"
+				remote = 0
+			else
+				user << "<span class='notice'>You push a hidden button and activate spirit photography.</span>"
+				remote = 1

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -463,8 +463,7 @@
 				wanted_players[M.real_name] = M
 		if(wanted in real_living_players)
 			target = input(user, "Who would you like to take a photograph of?", "Target name") as null|anything in wanted_players
-			var/turf/target_turf = get_turf(target)
-			if(target_turf.z == 2)
+			if(target.onCentcom())
 				target = user
 				user << "<span class='warning'>The spirit camera cannot reach out into that sector of the cosmos.</span>"
 				return

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -460,7 +460,6 @@
 			real_living_players[M.real_name] = M
 			if(M.real_name == wanted)
 				wanted_players += M
-				wanted_players[M] = M
 		if(wanted in real_living_players)
 			target = input(user, "Who would you like to take a photograph of?", "Target name") as null|anything in wanted_players
 			if(target.onCentcom())

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -390,14 +390,10 @@
 	user << "<span class='notice'>[pictures_left] photos left.</span>"
 	icon_state = "camera_off"
 	on = 0
-	if(!remote)
-		spawn(64)
-			icon_state = "camera"
-			on = 1
-	else
-		spawn(600)
-			icon_state = "camera"
-			on = 1
+	var/time = remote ? 600:64
+	spawn(time)
+		icon_state = "camera"
+		on = 1
 
 /obj/item/device/camera/siliconcam/proc/toggle_camera_mode()
 	if(in_camera_mode)
@@ -464,8 +460,13 @@
 		var/wanted = copytext(sanitize(input(user, "Who would you like to take a photograph of?", "Target name")as text | null),1,26)
 		if(wanted in real_living_players)
 			target = real_living_players[wanted]
+			var/turf/target_turf = get_turf(target)
+			if(target_turf.z == 2)
+				target = user
+				user << "<span class='warning'>The spirit camera cannot reach out into that sector of the cosmos.</span>"
+				return
 		else
 			target = user
 		if(isobj(target.loc))
-			target = target.loc
+			target = get_turf(target)
 	..()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -381,19 +381,6 @@
 		viewpichelper(Ainfo)
 
 /obj/item/device/camera/afterattack(atom/target, mob/user, flag)
-	if(remote && on && pictures_left)
-		var/list/living_players = living_mob_list
-		var/list/real_living_players = list()
-		for(var/mob/M in living_players)
-			real_living_players += M.real_name
-			real_living_players[M.real_name] = M
-		var/wanted = copytext(sanitize(input(user, "Who would you like to take a photograph of?", "Target name")as text | null),1,26)
-		if(wanted in real_living_players)
-			target = real_living_players[wanted]
-		else
-			target = user
-		if(isobj(target.loc))
-			target = target.loc
 	if(!on || !pictures_left || ismob(target.loc)) return
 	captureimage(target, user, flag)
 
@@ -466,3 +453,19 @@
 			else
 				user << "<span class='notice'>You push a hidden button and activate spirit photography.</span>"
 				remote = 1
+
+/obj/item/device/camera/spiritcam/afterattack(atom/target, mob/user, flag)
+	if(remote && on && pictures_left)
+		var/list/living_players = living_mob_list
+		var/list/real_living_players = list()
+		for(var/mob/M in living_players)
+			real_living_players += M.real_name
+			real_living_players[M.real_name] = M
+		var/wanted = copytext(sanitize(input(user, "Who would you like to take a photograph of?", "Target name")as text | null),1,26)
+		if(wanted in real_living_players)
+			target = real_living_players[wanted]
+		else
+			target = user
+		if(isobj(target.loc))
+			target = target.loc
+	..()

--- a/html/changelogs/Kierany9 - Spirit Camera.yml
+++ b/html/changelogs/Kierany9 - Spirit Camera.yml
@@ -1,0 +1,6 @@
+author: Kierany9
+
+delete-after: True
+
+changes: 
+  - rscadd: "Added the Spirit Camera as an item for all civilian traitors for 4 TC. When activated, input the name of your target and it will return a photo of them in their current location. If the person is dead or doesn't exist, you will get a photo of yourself."


### PR DESCRIPTION
Adds the Spirit Camera to the Traitor Uplink for all civilian jobs(Assistant, Librarian, Lawyer, Chaplain, Clown and Mime). This camera allows you to input the (real) name of any living mob and it will return a photo of them in their current location. If the person is dead or the name you put in was invalid, the photo will be of yourself instead. After taking a spirit photo (regardless of whether it worked or not), the camera will be on cooldown for sixty seconds. It can take up to 4 photos before needing a new film. It also works like a normal camera and can be toggled between modes by any antagonist who clicks on it.