### PR TITLE
Nuke Ops weapon tweaks

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -255,9 +255,9 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/specoffer/sniper
 	name = "Sniper bundle"
-	desc = "Contains a collapsed sniper rifle in an expensive carrying case, a hollowpoint haemorrhage magazine, a soporific knockout magazine, a free surplus supressor, and a worn out suit and tie."
+	desc = "Contains a collapsed sniper rifle in an expensive carrying case, a high explosive magazine, a soporific knockout magazine, a penetrator magazine, a free surplus supressor, and a worn out suit and tie."
 	item = /obj/item/weapon/storage/briefcase/sniperbundle
-	cost = 20//26 normal cost. suppressor is excluded from price.
+	cost = 22 //29 normal cost. suppressor is excluded from price.
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/specoffer/chemical
@@ -515,7 +515,7 @@ var/list/uplink_items = list()
 	name = "Sniper Rifle"
 	desc = "Ranged fury, syndicate style. Features a scope for precision fire."
 	item = /obj/item/weapon/gun/projectile/sniper_rifle
-	cost = 16
+	cost = 14
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 25
 
@@ -667,26 +667,26 @@ var/list/uplink_items = list()
 	name = "Sniper Magazine - .50"
 	desc = "An additional 5-round .50 magazine for use in the syndicate sniper rifle."
 	item = /obj/item/ammo_box/magazine/sniper_rounds
-	cost = 4 //70dmg rounds are no joke
+	cost = 5 //70dmg rounds are no joke
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/sniper/soporific
 	name = "Sniper Magazine - Soporific Rounds"
 	desc = "A 5-round magazine of soporific ammo designed for use in the syndicate sniper rifle, put your enemies to sleep today!"
 	item = /obj/item/ammo_box/magazine/sniper_rounds/soporific
-	cost = 2 //Why are sleep rounds more expensive than standard rounds, especially if it only comes with half the ammo?
+	cost = 3 //Why are sleep rounds more expensive than standard rounds, especially if it only comes with half the ammo?
 
 /datum/uplink_item/ammo/sniper/he
-	name = "Sniper Magazine - Haemorrhage Rounds"
+	name = "Sniper Magazine - Explosive Rounds"
 	desc = "A 5-round magazine of high-explosive ammo designed for use in the syndicate sniper rifle, causes a small explosion on impact."
 	item = /obj/item/ammo_box/magazine/sniper_rounds/he
-	cost = 5
+	cost = 6
 
 /datum/uplink_item/ammo/sniper/penetrator
 	name = "Sniper Magazine - Penetrator Rounds"
 	desc = "A 5-round magazine of penetrator ammo designed for use in the syndicate sniper rifle. Can pierce walls and multiple enemies."
 	item = /obj/item/ammo_box/magazine/sniper_rounds/penetrator
-	cost = 3
+	cost = 6
 
 // STEALTHY WEAPONS
 

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -355,7 +355,7 @@ var/list/uplink_items = list()
 	name = "Abzats Shotgun Machinegun"
 	desc = "A fully-loaded Aussec Armoury belt-fed machine gun. This deadly weapon has a massive 40-round box magazine of 12 gauge buckshot cartridges."
 	item = /obj/item/weapon/gun/projectile/automatic/shotgun/abzats
-	cost = 30
+	cost = 27
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
 
@@ -592,25 +592,25 @@ var/list/uplink_items = list()
 	cost = 2
 	gamemodes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/ammo/box12gbuckshot
+/datum/uplink_item/ammo/box12gbuckshot2 //you couldn't buy this because it had the same name as the box mag, good job whoever coded this
 	name = "40rnd ammo box - 12g Buckshot"
 	desc = "A box of 40 rounds of buckshot ammo, intended for reloading of the Abzats' box magazine."
 	item = /obj/item/ammo_box/box12gbuckshot
-	cost = 8
+	cost = 7
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/box12gbuckshot
 	name = "Abzats Spare Ammo Box - Buckshot"
 	desc = "An ammo box designed for use with the Abzats machine shotgun. Holds up to forty 12 gauge shotgun shells."
 	item = /obj/item/ammo_box/magazine/mbox12g
-	cost = 10
+	cost = 8
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/box12gdragon
 	name = "40rnd ammo box - 12g Dragon's breath"
 	desc = "A box of 40 rounds of dragon's breath ammo, intended for reloading of the Abzats' box magazine."
 	item = /obj/item/ammo_box/box12gdragon
-	cost = 12
+	cost = 9
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/bioterror

--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -652,29 +652,9 @@ var/list/uplink_items = list()
 	name = "Box Magazine - 7.62x51mm"
 	desc = "A 50-round magazine of 7.62x51mm ammunition for use in the L6 SAW machinegun. By the time you need to use this, you'll already be on a pile of corpses."
 	item = /obj/item/ammo_box/magazine/m762
-	cost = 6
+	cost = 5
 	gamemodes = list(/datum/game_mode/nuclear)
 	surplus = 0
-
-/datum/uplink_item/ammo/machinegun/bleeding
-	name = "Box Magazine - Bleeding 7.62x51mm"
-	desc = "A 50-round magazine of 7.62x51mm ammunition for use in the L6 SAW machinegun equipped with special properties to induce internal bleeding on targets."
-	item = /obj/item/ammo_box/magazine/m762/bleeding
-
-/datum/uplink_item/ammo/machinegun/hollow
-	name = "Box Magazine - Hollow 7.62x51mm"
-	desc = "A 50-round magazine of 7.62x51mm ammunition for use in the L6 SAW machinegun equipped with hollow-tips to help with the unarmored masses of crew."
-	item = /obj/item/ammo_box/magazine/m762/hollow
-
-/datum/uplink_item/ammo/machinegun/ap
-	name = "Box Magazine - Armor Penetrating 7.62x51mm"
-	desc = "A 50-round magazine of 7.62x51mm ammunition for use in the L6 SAW machinegun equipped with special properties to puncture even the most durable armor."
-	item = /obj/item/ammo_box/magazine/m762/ap
-
-/datum/uplink_item/ammo/machinegun/incen
-	name = "Box Magazine - Incendiary 7.62x51mm"
-	desc = "A 50-round magazine of 7.62x51mm ammunition for use in the L6 SAW machinegun, tipped with a special flammable mixture that'll ignite anyone struck by the bullet. Some men just want to watch the world burn."
-	item = /obj/item/ammo_box/magazine/m762/incen
 
 /datum/uplink_item/ammo/toydarts //This used to only be for nuke ops, but had the cost lowered and made available to traitors because >a box of foam darts is more expensive than four carbine magazines
 	name = "Box of Riot Darts"
@@ -685,27 +665,28 @@ var/list/uplink_items = list()
 
 /datum/uplink_item/ammo/sniper
 	name = "Sniper Magazine - .50"
-	desc = "An additional 6-round .50 magazine for use in the syndicate sniper rifle."
+	desc = "An additional 5-round .50 magazine for use in the syndicate sniper rifle."
 	item = /obj/item/ammo_box/magazine/sniper_rounds
 	cost = 4 //70dmg rounds are no joke
 	gamemodes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/sniper/soporific
 	name = "Sniper Magazine - Soporific Rounds"
-	desc = "A 3-round magazine of soporific ammo designed for use in the syndicate sniper rifle, put your enemies to sleep today!"
+	desc = "A 5-round magazine of soporific ammo designed for use in the syndicate sniper rifle, put your enemies to sleep today!"
 	item = /obj/item/ammo_box/magazine/sniper_rounds/soporific
-	cost = 5
+	cost = 2 //Why are sleep rounds more expensive than standard rounds, especially if it only comes with half the ammo?
 
-/datum/uplink_item/ammo/sniper/haemorrhage
+/datum/uplink_item/ammo/sniper/he
 	name = "Sniper Magazine - Haemorrhage Rounds"
-	desc = "A 5-round magazine of haemorrhage ammo designed for use in the syndicate sniper rifle, causes heavy bleeding in the target."
-	item = /obj/item/ammo_box/magazine/sniper_rounds/haemorrhage
+	desc = "A 5-round magazine of high-explosive ammo designed for use in the syndicate sniper rifle, causes a small explosion on impact."
+	item = /obj/item/ammo_box/magazine/sniper_rounds/he
+	cost = 5
 
 /datum/uplink_item/ammo/sniper/penetrator
 	name = "Sniper Magazine - Penetrator Rounds"
 	desc = "A 5-round magazine of penetrator ammo designed for use in the syndicate sniper rifle. Can pierce walls and multiple enemies."
 	item = /obj/item/ammo_box/magazine/sniper_rounds/penetrator
-	cost = 5
+	cost = 3
 
 // STEALTHY WEAPONS
 

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -42,10 +42,10 @@
 	burntime = 20
 
 /obj/item/weapon/storage/briefcase/sniperbundle/New()
-	..()
 	new /obj/item/weapon/gun/projectile/sniper_rifle(src)
 	new /obj/item/clothing/tie/red(src)
 	new /obj/item/clothing/under/syndicate/sniper(src)
 	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
-	new /obj/item/ammo_box/magazine/sniper_rounds/haemorrhage(src)
+	new /obj/item/ammo_box/magazine/sniper_rounds/he(src)
+	new /obj/item/ammo_box/magazine/sniper_rounds/penetrator(src)
 	new /obj/item/weapon/suppressor(src)

--- a/code/game/objects/items/weapons/storage/briefcase.dm
+++ b/code/game/objects/items/weapons/storage/briefcase.dm
@@ -42,6 +42,7 @@
 	burntime = 20
 
 /obj/item/weapon/storage/briefcase/sniperbundle/New()
+	..()
 	new /obj/item/weapon/gun/projectile/sniper_rifle(src)
 	new /obj/item/clothing/tie/red(src)
 	new /obj/item/clothing/under/syndicate/sniper(src)

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/automatic/l6_saw
 	name = "\improper L6 SAW"
-	desc = "A heavily modified 7.62 light machine gun, designated 'L6 SAW'. Has 'Aussec Armoury - 2531' engraved on the receiver below the designation."
+	desc = "A heavily modified 7.62 light machine gun, designated 'L6 SAW'. Has 'Aussec Armoury - 2531' engraved on the receiver below the designation. It is too heavy to fire properly with one hand, make sure your other hand is empty when shooting it."
 	icon_state = "l6closed100"
 	item_state = "l6closedmag"
 	w_class = 5

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -60,37 +60,8 @@
 
 
 /obj/item/projectile/bullet/saw
-	damage = 35
-	armour_penetration = 5
-
-/obj/item/projectile/bullet/saw/bleeding
-	damage = 15
-	armour_penetration = 0
-
-/obj/item/projectile/bullet/saw/bleeding/on_hit(atom/target, blocked = 0, hit_zone)
-	if((blocked != 100) && istype(target, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = target
-		H.drip(25)
-
-/obj/item/projectile/bullet/saw/hollow
-	damage = 45
-	armour_penetration = 0
-
-/obj/item/projectile/bullet/saw/ap
-	damage = 30
-	armour_penetration = 35
-
-/obj/item/projectile/bullet/saw/incen
-	damage = 5
-	armour_penetration = 0
-
-/obj/item/projectile/bullet/saw/incen/on_hit(atom/target, blocked = 0)
-	. = ..()
-	if(iscarbon(target))
-		var/mob/living/carbon/M = target
-		M.adjust_fire_stacks(1)
-		M.IgniteMob()
-
+	damage = 60
+	armour_penetration = 40
 
 //magazines//
 
@@ -102,26 +73,6 @@
 	ammo_type = /obj/item/ammo_casing/a762
 	caliber = "a762"
 	max_ammo = 50
-
-/obj/item/ammo_box/magazine/m762/bleeding
-	name = "box magazine (Bleeding 7.62mm)"
-	origin_tech = "combat=3"
-	ammo_type = /obj/item/ammo_casing/a762/bleeding
-
-/obj/item/ammo_box/magazine/m762/hollow
-	name = "box magazine (Hollow-Point 7.62mm)"
-	origin_tech = "combat=3"
-	ammo_type = /obj/item/ammo_casing/a762/hollow
-
-/obj/item/ammo_box/magazine/m762/ap
-	name = "box magazine (Armor Penetrating 7.62mm)"
-	origin_tech = "combat=4"
-	ammo_type = /obj/item/ammo_casing/a762/ap
-
-/obj/item/ammo_box/magazine/m762/incen
-	name = "box magazine (Incendiary 7.62mm)"
-	origin_tech = "combat=4"
-	ammo_type = /obj/item/ammo_casing/a762/incen
 
 /obj/item/ammo_box/magazine/m762/update_icon()
 	..()
@@ -136,21 +87,3 @@
 	icon_state = "762-casing"
 	caliber = "a762"
 	projectile_type = /obj/item/projectile/bullet/saw
-
-/obj/item/ammo_casing/a762/bleeding
-	desc = "A 7.62mm bullet casing with specialized inner-casing, that when it makes contact with a target, release tiny shrapnel to induce internal bleeding."
-	icon_state = "762-casing"
-	caliber = "a762"
-	projectile_type = /obj/item/projectile/bullet/saw/bleeding
-
-/obj/item/ammo_casing/a762/hollow
-	desc = "A 7.62mm bullet casing designed to cause more damage to unarmored targets."
-	projectile_type = /obj/item/projectile/bullet/saw/hollow
-
-/obj/item/ammo_casing/a762/ap
-	desc = "A 7.62mm bullet casing designed with a hardened-tipped core to help penetrate armored targets."
-	projectile_type = /obj/item/projectile/bullet/saw/ap
-
-/obj/item/ammo_casing/a762/incen
-	desc = "A 7.62mm bullet casing designed with a chemical-filled capsule on the tip that when bursted, reacts with the atmosphere to produce a fireball, engulfing the target in flames. "
-	projectile_type = /obj/item/projectile/bullet/saw/incen

--- a/code/modules/projectiles/guns/projectile/saw.dm
+++ b/code/modules/projectiles/guns/projectile/saw.dm
@@ -61,7 +61,7 @@
 
 /obj/item/projectile/bullet/saw
 	damage = 60
-	armour_penetration = 40
+	armour_penetration = 10
 
 //magazines//
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -55,6 +55,11 @@
 /obj/item/projectile/bullet/sniper/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && (!ismob(target) && breakthings))
 		target.ex_act(rand(1,2))
+	if((blocked != 100) && ishuman(target) && (hit_zone != ("chest" || "head")) && breakthings)
+		var/mob/living/carbon/human/H = target
+		var/obj/item/organ/limb/O = H.get_organ(hit_zone)
+		O.dismember()
+
 
 	return ..()
 
@@ -90,35 +95,33 @@
 	return ..()
 
 
-//hemorrhage ammo
-/obj/item/ammo_box/magazine/sniper_rounds/haemorrhage
-	name = "sniper rounds (Bleed)"
-	desc = "Haemorrhage sniper rounds, leaves your target in a pool of crimson pain"
+//high-explosive ammo
+/obj/item/ammo_box/magazine/sniper_rounds/he
+	name = "sniper rounds (Explosive)"
+	desc = "High explosive rounds deal high ammounts of collateral damage in a 1-tile radius"
 	icon_state = "haemorrhage"
 	origin_tech = "combat=7;syndicate=5"
-	ammo_type = /obj/item/ammo_casing/haemorrhage
+	ammo_type = /obj/item/ammo_casing/he
 	max_ammo = 5
 	caliber = ".50"
 
-/obj/item/ammo_casing/haemorrhage
+/obj/item/ammo_casing/he
 	desc = "A .50 bullet casing, specialised in causing massive bloodloss"
 	caliber = ".50"
-	projectile_type = /obj/item/projectile/bullet/sniper/haemorrhage
+	projectile_type = /obj/item/projectile/bullet/sniper/he
 	icon_state = ".50"
 
-/obj/item/projectile/bullet/sniper/haemorrhage
-	armour_penetration = 15
-	damage = 15
+/obj/item/projectile/bullet/sniper/he
+	armour_penetration = 0
+	damage = 40
 	stun = 0
 	weaken = 0
-	breakthings = FALSE
+	breakthings = TRUE
 
-/obj/item/projectile/bullet/sniper/haemorrhage/on_hit(atom/target, blocked = 0, hit_zone)
-	if((blocked != 100) && istype(target, /mob/living/carbon/human))
-		var/mob/living/carbon/human/H = target
-		H.drip(100)
-
-	return ..()
+/obj/item/projectile/bullet/sniper/he/on_hit(atom/target, blocked = 0, hit_zone)
+	..()
+	explosion(target, -1, 0, 2)
+	return 1
 
 
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -30,7 +30,7 @@
 	icon_state = ".50mag"
 	origin_tech = "combat=6;syndicate=2"
 	ammo_type = /obj/item/ammo_casing/point50
-	max_ammo = 6
+	max_ammo = 5
 	caliber = ".50"
 
 /obj/item/ammo_box/magazine/sniper_rounds/update_icon()
@@ -71,7 +71,7 @@
 	icon_state = "soporific"
 	origin_tech = "combat=6;syndicate=3"
 	ammo_type = /obj/item/ammo_casing/soporific
-	max_ammo = 3
+	max_ammo = 5
 	caliber = ".50"
 
 /obj/item/ammo_casing/soporific

--- a/html/changelogs/Kierany9 - Newcops.yml
+++ b/html/changelogs/Kierany9 - Newcops.yml
@@ -3,7 +3,7 @@ author: Kierany9
 delete-after: True
 
 changes: 
-- rscadd: "Nuke Ops Sniper Rifles can now remove limbs if they happen to hit one if they're using standard or HE ammunition!"
+- rscadd: "Nuke Ops Sniper Rifles can now remove targeted limbs if they're using standard or HE ammunition!"
 - rscadd: "Replaced hemorrhage sniper rounds with high-explosive rounds. These do 40 damage and explode in a 1-tile radius. Like standard rounds, these can break walls and delimb on hit as well, potentially removing multiple limbs."
 - tweak: "Reverted the L6 SAW's damage from 35 back to 60, along with 10 armour penetration."
 - rscdel: "Removed additional ammo types for the L6 SAW."

--- a/html/changelogs/Kierany9 - Newcops.yml
+++ b/html/changelogs/Kierany9 - Newcops.yml
@@ -1,0 +1,11 @@
+author: Kierany9
+
+delete-after: True
+
+changes: 
+- rscadd: "Nuke Ops Sniper Rifles can now remove limbs if they happen to hit one if they're using standard or HE ammunition!"
+- rscadd: "Replaced hemorrhage sniper rounds with high-explosive rounds. These do 40 damage and explode in a 1-tile radius. Like standard rounds, these can break walls and delimb on hit as well, potentially removing multiple limbs."
+- tweak: "Reverted the L6 SAW's damage from 35 back to 60, along with 10 armour penetration."
+- rscdel: "Removed additional ammo types for the L6 SAW."
+- tweak: "Adjusted several prices for Nuke Ops items, including sniper ammunition and the Abzats."
+- bugfix: "Fixed a bug where buckshot ammo boxes didn't show up on the uplink."

--- a/html/changelogs/Kierany9 - Newcops.yml
+++ b/html/changelogs/Kierany9 - Newcops.yml
@@ -3,9 +3,9 @@ author: Kierany9
 delete-after: True
 
 changes: 
-- rscadd: "Nuke Ops Sniper Rifles can now remove targeted limbs if they're using standard or HE ammunition!"
-- rscadd: "Replaced hemorrhage sniper rounds with high-explosive rounds. These do 40 damage and explode in a 1-tile radius. Like standard rounds, these can break walls and delimb on hit as well, potentially removing multiple limbs."
-- tweak: "Reverted the L6 SAW's damage from 35 back to 60, along with 10 armour penetration."
-- rscdel: "Removed additional ammo types for the L6 SAW."
-- tweak: "Adjusted several prices for Nuke Ops items, including sniper ammunition and the Abzats."
-- bugfix: "Fixed a bug where buckshot ammo boxes didn't show up on the uplink."
+  - rscadd: "Nuke Ops Sniper Rifles can now remove targeted limbs if they're using standard or HE ammunition!"
+  - rscadd: "Replaced hemorrhage sniper rounds with high-explosive rounds. These do 40 damage and explode in a 1-tile radius. Like standard rounds, these can break walls and delimb on hit as well, potentially removing multiple limbs."
+  - tweak: "Reverted the L6 SAW's damage from 35 back to 60, along with 10 armour penetration."
+  - rscdel: "Removed additional ammo types for the L6 SAW."
+  - tweak: "Adjusted several prices for Nuke Ops items, including sniper ammunition and the Abzats."
+  - bugfix: "Fixed a bug where buckshot ammo boxes didn't show up on the uplink."


### PR DESCRIPTION
Minor nuke ops weapon changes that remove bloat and hopefully make these weapons more useful.

### Sniper Rifle (14 TC)
- **Sniper Rifles now dismember targeted limbs when using standard or high-explosive ammo.** Can't remove the head or chest for obvious reasons.
- **Replaced haemorrhage rounds with high-explosive rounds.** These deal 40 damage with no armour penetration(as opposed to 70 damage and 50 AP) but explode in a 1-tile radius(3x3 area) similar to the gyrojet pisol. Like regular rounds, these can delimb and break through walls.
- All sniper magazines now hold five shots regardless of type (Standard held 6, Sleepy held 3, Penetrator held 5).
- Sniper bundle now contains a HE magazine and costs 2 TC more (20 -> 22)
- Decreased the price from 16 TC to 14 TC. However, the price of ammo has gone up (Standard: 4 -> 5, Sleepy: 5 -> 3, High Explosive: 6, Penetrator: 5 -> 6)

### L6 SAW (23 TC)
- **Reverts the nerf to its firepower, bullets now deal 60 damage instead of 35.** Now also has 10 armour penetration.
- **Removed all the special ammo types.** There was no practical use for any of these. Haemorrage and Incendiary had laughable damage outputs(5 and 15 per shot respectively) whereas AP and hollow were simpe stat variations that changed very little when compared to standard rounds.
- Ammo decreased from 6 TC to 5 TC

### Abzats (27 TC)
- Decreased price from 30 TC to 27 TC to compensate for the SAW buff.
- Decreased the price of its spare ammo. (40-round buckshot box: 8 -> 7, 40 round dragonsbreath box: 12 -> 9, 40-round buckshot magazine: 10 -> 8)
- **Fixed a bug where 40-round buckshot boxes could not be purchased from the uplink.**