### PR TITLE
Nuke Ops can customize their declaration of war

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -301,6 +301,9 @@
 			M << "That name is reserved."
 			return nukelastname(M)
 
+	for(var/obj/item/device/nuclear_challenge/C)
+		C.last_name = capitalize(newname)
+
 	return capitalize(newname)
 
 /proc/NukeNameAssign(lastname,list/syndicates)

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -292,6 +292,7 @@
 
 /proc/nukelastname(mob/M) //--All praise goes to NEO|Phyte, all blame goes to DH, and it was Cindi-Kate's idea. Also praise Urist for copypasta ho.
 	var/randomname = pick(last_names)
+	var/datum/game_mode/nuclear/N = ticker.mode 
 	var/newname = copytext(sanitize(input(M,"You are the nuke operative [pick("Czar", "Boss", "Commander", "Chief", "Kingpin", "Director", "Overlord")]. Please choose a last name for your family.", "Name change",randomname)),1,MAX_NAME_LEN)
 
 	if (!newname)
@@ -302,7 +303,8 @@
 			M << "That name is reserved."
 			return nukelastname(M)
 
-	ticker.mode:last_name = capitalize(newname)
+	if(istype(N))
+		N.last_name = capitalize(newname)
 
 	return capitalize(newname)
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -16,6 +16,7 @@
 	var/nukes_left = 1 // Call 3714-PRAY right now and order more nukes! Limited offer!
 	var/nuke_off_station = 0 //Used for tracking if the syndies actually haul the nuke to the station
 	var/syndies_didnt_escape = 0 //Used for tracking if the syndies got the shuttle off of the z-level
+	var/last_name = "Syndicate" //Last name of the syndicates, used for war declarations
 
 /datum/game_mode/nuclear/announce()
 	world << "<B>The current game mode is - Nuclear Emergency!</B>"
@@ -301,8 +302,7 @@
 			M << "That name is reserved."
 			return nukelastname(M)
 
-	for(var/obj/item/device/nuclear_challenge/C)
-		C.last_name = capitalize(newname)
+	ticker.mode:last_name = capitalize(newname)
 
 	return capitalize(newname)
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -9,7 +9,7 @@
 	Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
 	Must be used within five minutes, or your benefactors will lose interest."
 	var/used = 0
-	var/ops_mode = ticker.mode
+	var/challenge_time = CHALLENGE_TIME_LIMIT
 
 
 
@@ -23,14 +23,14 @@
 		user << "You have to be at your base to use this."
 		return
 
-	if(world.time > CHALLENGE_TIME_LIMIT)
+	if(world.time > challenge_time)
 		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
 		return
 
 	if(used) //First used check
 		return
 
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [round((CHALLENGE_TIME_LIMIT - world.time)/10)] seconds to decide", "Declare war?", "Yes", "No")
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [round((challenge_time - world.time)/10)] seconds to decide", "Declare war?", "Yes", "No")
 	if(are_you_sure == "No")
 		user << "On second thought, the element of surprise isn't so bad after all."
 		return
@@ -41,14 +41,14 @@
 	
 	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
 	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
-	if(custom_threat == "Yes" && (world.time < CHALLENGE_TIME_LIMIT-600))
+	if(custom_threat == "Yes" && (world.time < challenge_time-600))
 		war_declaration = stripped_input(user, "Insert your custom declaration", "Declaration")
 		if(!war_declaration)
 			return
-	else if(world.time > CHALLENGE_TIME_LIMIT-600)
+	else if(world.time > challenge_time-600)
 		user << "You don't have enough time to come up with any evil speeches now!"
 
-	if(world.time > CHALLENGE_TIME_LIMIT) //Check the time limit again in case somebody intentionally holds the dialogue box to delay declarations
+	if(world.time > challenge_time) //Check the time limit again in case somebody intentionally holds the dialogue box to delay declarations
 		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
 		return
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -30,7 +30,7 @@
 	if(used) //First used check
 		return
 
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [round((CHALLENGE_TIME_LIMIT - world.time)/600)] minutes to decide", "Declare war?", "Yes", "No")
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [round((CHALLENGE_TIME_LIMIT - world.time)/10)] seconds to decide", "Declare war?", "Yes", "No")
 	if(are_you_sure == "No")
 		user << "On second thought, the element of surprise isn't so bad after all."
 		return
@@ -42,8 +42,8 @@
 	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
 	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
 	if(custom_threat == "Yes" && (world.time < CHALLENGE_TIME_LIMIT-600))
-		war_declaration = sanitize(input(user, "Insert your custom declaration", "Declaration")as text | null)
-		if(war_declaration == null)
+		war_declaration = copytext(sanitize(input(user, "Insert your custom declaration", "Declaration")as text | null), 1, 500)
+		if(war_declaration == null || war_declaration == "")
 			return
 	else if(world.time > CHALLENGE_TIME_LIMIT-600)
 		user << "You don't have enough time to come up with any evil speeches now!"

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -24,7 +24,7 @@
 		return
 
 	if(world.time > CHALLENGE_TIME_LIMIT)
-		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand."
+		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
 		return
 
 	if(used) //First used check
@@ -49,7 +49,7 @@
 		user << "You don't have enough time to come up with any evil speeches now!"
 
 	if(world.time > CHALLENGE_TIME_LIMIT) //Check the time limit again in case somebody intentionally holds the dialogue box to delay declarations
-		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand."
+		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
 		return
 
 	used = 1

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -29,7 +29,7 @@
 	if(used) //First used check
 		return
 
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew?", "Declare war?", "Yes", "No")
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You have [round((CHALLENGE_TIME_LIMIT - world.time)/600)] minutes to decide", "Declare war?", "Yes", "No")
 	if(are_you_sure == "No")
 		user << "On second thought, the element of surprise isn't so bad after all."
 		return
@@ -37,10 +37,21 @@
 	if(used) //Second used check incase it's sustained in the dialog
 		user << "You already declared war on the station!"
 		return
+	
+	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
+	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
+	if(custom_threat == "Yes" && (world.time < CHALLENGE_TIME_LIMIT-600))
+		war_declaration = sanitize(input(user, "Insert your custom declaration", "Declaration")as text | null)
+	else if(world.time > CHALLENGE_TIME_LIMIT-600)
+		user << "You don't have enough time to come up with any evil speeches now!"
+
+	if(world.time > CHALLENGE_TIME_LIMIT) //Check the time limit again in case somebody intentionally holds the dialogue box to delay declarations
+		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand."
+		return
 
 	used = 1
-	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
-	priority_announce(war_declaration, title = "Declaration of War", sound = 'sound/machines/Alarm.ogg')
+
+	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by [user.real_name]", sound = 'sound/machines/Alarm.ogg')
 	set_security_level(SEC_LEVEL_RED)
 	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -42,8 +42,8 @@
 	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
 	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
 	if(custom_threat == "Yes" && (world.time < CHALLENGE_TIME_LIMIT-600))
-		war_declaration = copytext(sanitize(input(user, "Insert your custom declaration", "Declaration")as text | null), 1, 500)
-		if(war_declaration == null || war_declaration == "")
+		war_declaration = stripped_input(user, "Insert your custom declaration", "Declaration")
+		if(!war_declaration)
 			return
 	else if(world.time > CHALLENGE_TIME_LIMIT-600)
 		user << "You don't have enough time to come up with any evil speeches now!"

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -16,59 +16,60 @@
 	N = ticker.mode
 
 /obj/item/device/nuclear_challenge/attack_self(mob/living/user)
-	if(istype(N))
-		if(..())
+	if(!istype(N))
+		return
+	if(..())
+		return
+	if(player_list.len < MIN_CHALLENGE_PLAYERS)
+		user << "The enemy crew is too small to be worth declaring war on."
+		return
+	if(user.z != ZLEVEL_CENTCOM)
+		user << "You have to be at your base to use this."
+		return
+
+	if(world.time > challenge_time)
+		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
+		return
+
+	if(used) //First used check
+		return
+
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [round((challenge_time - world.time)/10)] seconds to decide", "Declare war?", "Yes", "No")
+	if(are_you_sure == "No")
+		user << "On second thought, the element of surprise isn't so bad after all."
+		return
+
+	if(used) //Second used check incase it's sustained in the dialog
+		user << "You already declared war on the station!"
+		return
+	
+	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
+	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
+	if(custom_threat == "Yes" && (world.time < challenge_time-600))
+		war_declaration = stripped_input(user, "Insert your custom declaration", "Declaration")
+		if(!war_declaration)
 			return
-		if(player_list.len < MIN_CHALLENGE_PLAYERS)
-			user << "The enemy crew is too small to be worth declaring war on."
-			return
-		if(user.z != ZLEVEL_CENTCOM)
-			user << "You have to be at your base to use this."
-			return
-	
-		if(world.time > challenge_time)
-			user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
-			return
-	
-		if(used) //First used check
-			return
-	
-		var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [round((challenge_time - world.time)/10)] seconds to decide", "Declare war?", "Yes", "No")
-		if(are_you_sure == "No")
-			user << "On second thought, the element of surprise isn't so bad after all."
-			return
-	
-		if(used) //Second used check incase it's sustained in the dialog
-			user << "You already declared war on the station!"
-			return
-		
-		var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
-		var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
-		if(custom_threat == "Yes" && (world.time < challenge_time-600))
-			war_declaration = stripped_input(user, "Insert your custom declaration", "Declaration")
-			if(!war_declaration)
-				return
-		else if(world.time > challenge_time-600)
-			user << "You don't have enough time to come up with any evil speeches now!"
-	
-		if(world.time > challenge_time) //Check the time limit again in case somebody intentionally holds the dialogue box to delay declarations
-			user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
-			return
-	
-		used = 1
-	
-		priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by the [N.last_name] family", sound = 'sound/machines/Alarm.ogg')
-		set_security_level(SEC_LEVEL_RED)
-		user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
-	
-		for(var/obj/machinery/computer/shuttle/syndicate/S in machines)
-			S.challenge = TRUE
-	
-		var/obj/item/device/radio/uplink/U = new /obj/item/device/radio/uplink(get_turf(user))
-		U.hidden_uplink.uplink_owner= "[user.key]"
-		U.hidden_uplink.uses = 200
-		U.hidden_uplink.mode_override = /datum/game_mode/nuclear //Maybe we can have a special set of items for the challenge uplink eventually
-		qdel(src)
+	else if(world.time > challenge_time-600)
+		user << "You don't have enough time to come up with any evil speeches now!"
+
+	if(world.time > challenge_time) //Check the time limit again in case somebody intentionally holds the dialogue box to delay declarations
+		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
+		return
+
+	used = 1
+
+	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by the [N.last_name] family", sound = 'sound/machines/Alarm.ogg')
+	set_security_level(SEC_LEVEL_RED)
+	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
+
+	for(var/obj/machinery/computer/shuttle/syndicate/S in machines)
+		S.challenge = TRUE
+
+	var/obj/item/device/radio/uplink/U = new /obj/item/device/radio/uplink(get_turf(user))
+	U.hidden_uplink.uplink_owner= "[user.key]"
+	U.hidden_uplink.uses = 200
+	U.hidden_uplink.mode_override = /datum/game_mode/nuclear //Maybe we can have a special set of items for the challenge uplink eventually
+	qdel(src)
 
 
 #undef CHALLENGE_TIME_LIMIT

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -1,4 +1,4 @@
-#define CHALLENGE_TIME_LIMIT 3000
+#define CHALLENGE_TIME_LIMIT 4200 //2 minutes are spent dicking around in the lobby so you only used to have 3 minutes to declare or not declare
 #define MIN_CHALLENGE_PLAYERS 50
 
 /obj/item/device/nuclear_challenge
@@ -54,7 +54,7 @@
 
 	used = 1
 
-	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by the [last_name] family", sound = 'sound/machines/Alarm.ogg')
+	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by the [ticker.mode:last_name] family", sound = 'sound/machines/Alarm.ogg')
 	set_security_level(SEC_LEVEL_RED)
 	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -42,6 +42,8 @@
 	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
 	if(custom_threat == "Yes" && (world.time < CHALLENGE_TIME_LIMIT-600))
 		war_declaration = sanitize(input(user, "Insert your custom declaration", "Declaration")as text | null)
+		if(war_declaration == null)
+			return
 	else if(world.time > CHALLENGE_TIME_LIMIT-600)
 		user << "You don't have enough time to come up with any evil speeches now!"
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -9,6 +9,7 @@
 	Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
 	Must be used within five minutes, or your benefactors will lose interest."
 	var/used = 0
+	var/last_name = "Syndicate"
 
 
 
@@ -29,7 +30,7 @@
 	if(used) //First used check
 		return
 
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You have [round((CHALLENGE_TIME_LIMIT - world.time)/600)] minutes to decide", "Declare war?", "Yes", "No")
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [round((CHALLENGE_TIME_LIMIT - world.time)/600)] minutes to decide", "Declare war?", "Yes", "No")
 	if(are_you_sure == "No")
 		user << "On second thought, the element of surprise isn't so bad after all."
 		return

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -54,7 +54,7 @@
 
 	used = 1
 
-	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by [last_name]", sound = 'sound/machines/Alarm.ogg')
+	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by the [last_name] family", sound = 'sound/machines/Alarm.ogg')
 	set_security_level(SEC_LEVEL_RED)
 	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -10,62 +10,65 @@
 	Must be used within five minutes, or your benefactors will lose interest."
 	var/used = 0
 	var/challenge_time = CHALLENGE_TIME_LIMIT
+	var/datum/game_mode/nuclear/N
 
-
+/obj/item/device/nuclear_challenge/New()
+	N = ticker.mode
 
 /obj/item/device/nuclear_challenge/attack_self(mob/living/user)
-	if(..())
-		return
-	if(player_list.len < MIN_CHALLENGE_PLAYERS)
-		user << "The enemy crew is too small to be worth declaring war on."
-		return
-	if(user.z != ZLEVEL_CENTCOM)
-		user << "You have to be at your base to use this."
-		return
-
-	if(world.time > challenge_time)
-		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
-		return
-
-	if(used) //First used check
-		return
-
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [round((challenge_time - world.time)/10)] seconds to decide", "Declare war?", "Yes", "No")
-	if(are_you_sure == "No")
-		user << "On second thought, the element of surprise isn't so bad after all."
-		return
-
-	if(used) //Second used check incase it's sustained in the dialog
-		user << "You already declared war on the station!"
-		return
-	
-	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
-	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
-	if(custom_threat == "Yes" && (world.time < challenge_time-600))
-		war_declaration = stripped_input(user, "Insert your custom declaration", "Declaration")
-		if(!war_declaration)
+	if(istype(N))
+		if(..())
 			return
-	else if(world.time > challenge_time-600)
-		user << "You don't have enough time to come up with any evil speeches now!"
-
-	if(world.time > challenge_time) //Check the time limit again in case somebody intentionally holds the dialogue box to delay declarations
-		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
-		return
-
-	used = 1
-
-	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by the [ops_mode.last_name] family", sound = 'sound/machines/Alarm.ogg')
-	set_security_level(SEC_LEVEL_RED)
-	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
-
-	for(var/obj/machinery/computer/shuttle/syndicate/S in machines)
-		S.challenge = TRUE
-
-	var/obj/item/device/radio/uplink/U = new /obj/item/device/radio/uplink(get_turf(user))
-	U.hidden_uplink.uplink_owner= "[user.key]"
-	U.hidden_uplink.uses = 200
-	U.hidden_uplink.mode_override = /datum/game_mode/nuclear //Maybe we can have a special set of items for the challenge uplink eventually
-	qdel(src)
+		if(player_list.len < MIN_CHALLENGE_PLAYERS)
+			user << "The enemy crew is too small to be worth declaring war on."
+			return
+		if(user.z != ZLEVEL_CENTCOM)
+			user << "You have to be at your base to use this."
+			return
+	
+		if(world.time > challenge_time)
+			user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
+			return
+	
+		if(used) //First used check
+			return
+	
+		var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]. Are you sure you want to alert the enemy crew? You have [round((challenge_time - world.time)/10)] seconds to decide", "Declare war?", "Yes", "No")
+		if(are_you_sure == "No")
+			user << "On second thought, the element of surprise isn't so bad after all."
+			return
+	
+		if(used) //Second used check incase it's sustained in the dialog
+			user << "You already declared war on the station!"
+			return
+		
+		var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
+		var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
+		if(custom_threat == "Yes" && (world.time < challenge_time-600))
+			war_declaration = stripped_input(user, "Insert your custom declaration", "Declaration")
+			if(!war_declaration)
+				return
+		else if(world.time > challenge_time-600)
+			user << "You don't have enough time to come up with any evil speeches now!"
+	
+		if(world.time > challenge_time) //Check the time limit again in case somebody intentionally holds the dialogue box to delay declarations
+			user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
+			return
+	
+		used = 1
+	
+		priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by the [N.last_name] family", sound = 'sound/machines/Alarm.ogg')
+		set_security_level(SEC_LEVEL_RED)
+		user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
+	
+		for(var/obj/machinery/computer/shuttle/syndicate/S in machines)
+			S.challenge = TRUE
+	
+		var/obj/item/device/radio/uplink/U = new /obj/item/device/radio/uplink(get_turf(user))
+		U.hidden_uplink.uplink_owner= "[user.key]"
+		U.hidden_uplink.uses = 200
+		U.hidden_uplink.mode_override = /datum/game_mode/nuclear //Maybe we can have a special set of items for the challenge uplink eventually
+		qdel(src)
 
 
 #undef CHALLENGE_TIME_LIMIT

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -9,6 +9,7 @@
 	Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
 	Must be used within five minutes, or your benefactors will lose interest."
 	var/used = 0
+	var/ops_mode = ticker.mode
 
 
 
@@ -53,7 +54,7 @@
 
 	used = 1
 
-	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by the [ticker.mode:last_name] family", sound = 'sound/machines/Alarm.ogg')
+	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by the [ops_mode.last_name] family", sound = 'sound/machines/Alarm.ogg')
 	set_security_level(SEC_LEVEL_RED)
 	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -54,7 +54,7 @@
 
 	used = 1
 
-	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by [user.real_name]", sound = 'sound/machines/Alarm.ogg')
+	priority_announce(replacetext(war_declaration, "&#39;","'"), title = "Declaration of War by [last_name]", sound = 'sound/machines/Alarm.ogg')
 	set_security_level(SEC_LEVEL_RED)
 	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
 

--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -9,7 +9,6 @@
 	Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
 	Must be used within five minutes, or your benefactors will lose interest."
 	var/used = 0
-	var/last_name = "Syndicate"
 
 
 

--- a/code/game/machinery/computer/syndicate_shuttle.dm
+++ b/code/game/machinery/computer/syndicate_shuttle.dm
@@ -1,4 +1,4 @@
-#define SYNDICATE_CHALLENGE_TIMER 9000 //15 minutes
+#define SYNDICATE_CHALLENGE_TIMER 10200 //17 minutes, 2 of those are spent in the lobby
 
 /obj/machinery/computer/shuttle/syndicate
 	name = "syndicate shuttle terminal"

--- a/html/changelogs/Kierany9 - Declaration.yml
+++ b/html/changelogs/Kierany9 - Declaration.yml
@@ -5,3 +5,4 @@ delete-after: True
 changes: 
   - rscadd: "Nuke Ops can now customize their declaration of war message!"
   - bugfix: "Fixed a bug where Nuke Ops could declare war after the timer had expired."
+  - bugfix: "The time window to declare war is now actually five minutes instead of three."

--- a/html/changelogs/Kierany9 - Declaration.yml
+++ b/html/changelogs/Kierany9 - Declaration.yml
@@ -1,0 +1,7 @@
+author: Kierany9
+
+delete-after: True
+
+changes: 
+  - rscadd: "Nuke Ops can now customize their declaration of war message!"
+  - bugfix: "Fixed a bug where Nuke Ops could declare war after the timer had expired."


### PR DESCRIPTION
![ayy lmao](http://i.imgur.com/s1ZcKxL.png?1)

- Nuke Ops can now customize the message broadcast to the station when declaring war.
- The declaration tool now tells you how long you have left to decide when the activation prompt shows up.
- Fixed a bug where nuke ops could wait indefinitely before declaring war.
- Fixed the nuke ops having less time than they should to declare war.