### PR TITLE
Fixes a runtime with addictions

### DIFF
--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -245,7 +245,7 @@ var/const/INJECT = 5 //injection
 				R.on_mob_life(M)
 
 	if(can_overdose)
-		if(addiction_tick == 6)
+		if(addiction_tick == 4)
 			addiction_tick = 1
 			for(var/datum/reagent/R in addiction_list)
 				if(M && R)

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -247,8 +247,7 @@ var/const/INJECT = 5 //injection
 	if(can_overdose)
 		if(addiction_tick == 6)
 			addiction_tick = 1
-			for(var/A in addiction_list)
-				var/datum/reagent/R = A
+			for(var/datum/reagent/R in addiction_list)
 				if(M && R)
 					if(R.addiction_stage <= 0)
 						R.addiction_stage++

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -245,7 +245,7 @@ var/const/INJECT = 5 //injection
 				R.on_mob_life(M)
 
 	if(can_overdose)
-		if(addiction_tick == 4)
+		if(addiction_tick == 6)
 			addiction_tick = 1
 			for(var/datum/reagent/R in addiction_list)
 				if(M && R)

--- a/html/changelogs/Kierany9 - Runtime.yml
+++ b/html/changelogs/Kierany9 - Runtime.yml
@@ -6,4 +6,3 @@ delete-after: True
 
 changes: 
   - bugfix: "Fixed a runtime error that was causing addictions not to work."
-  - tweak: "Slightly reduced the time addictions last, jesus christ these things are brutal."

--- a/html/changelogs/Kierany9 - Runtime.yml
+++ b/html/changelogs/Kierany9 - Runtime.yml
@@ -1,0 +1,9 @@
+# Your name.  
+author: Kierany9
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+changes: 
+  - bugfix: "Fixed a runtime error that was causing addictions not to work."
+  - tweak: "Slightly reduced the time addictions last, jesus christ these things are brutal."


### PR DESCRIPTION
For the record, I only have a vague idea of how what I did fixes the runtime, but it stops addictions from spewing out runtimes every tick and addictions now work properly. **Although I'd rather have this merged *after* we can isolate the cause of, and fix, the server stability problems we're having right now.** Also, I'd suggest reducing the duration of addictions as they are extremely crippling, have no cure and can take people out of the round for at least 10 minutes, or kill them if they can't get to the medbay on time. Not doing it here because I don't want a runtime fix to get boged with features that'll end up needing HA approval.

![it just works](http://i0.kym-cdn.com/photos/images/facebook/000/469/562/d00.png)