### PR TITLE
Reduces King of the Disk's minimum playercount by 10

### DIFF
--- a/code/game/gamemodes/traitor/king_disk.dm
+++ b/code/game/gamemodes/traitor/king_disk.dm
@@ -1,7 +1,7 @@
 /datum/game_mode/traitor/king_disk
 	name = "king of the disk"
 	config_tag = "king_disk"
-	required_players = 45
+	required_players = 35 // We aren't even hitting 45 players unfortunately.
 	required_enemies = 8
 	recommended_enemies = 10
 	reroll_friendly = 0

--- a/html/changelogs/Kierany9 - KotDplayers.yml
+++ b/html/changelogs/Kierany9 - KotDplayers.yml
@@ -1,0 +1,4 @@
+author: Kierany9
+delete-after: True
+changes: 
+  - tweak: "King of the Disk now needs 35 players to start instead of 45."


### PR DESCRIPTION
While King of the Disk is most definitely designed for higher populations of players, we're rarely hitting 45 players at roundstart, meaning that it almost never gets played. And from the few rounds I've seen, it's been far less of a murderfest than Double Agents or Revolution, which need 25 and 20 players minimum respectively.