### PR TITLE
Krav Maga Ability - Heavy Tackle

### DIFF
--- a/code/modules/martial arts/krav_maga.dm
+++ b/code/modules/martial arts/krav_maga.dm
@@ -183,6 +183,8 @@
 				A.adjustStaminaLoss(60)
 				shake_camera(A, 3, 1)
 				shake_camera(D, 3, 1)
+				for(var/datum/reagent/R in A.reagents.reagent_list)
+					R.stun_timer = 0
 				if(!A.stat && A.Adjacent(D))
 					A.forceMove(D.loc)
 				playsound(D, 'sound/effects/bang.ogg', 50, 1)

--- a/code/modules/martial arts/krav_maga.dm
+++ b/code/modules/martial arts/krav_maga.dm
@@ -167,7 +167,7 @@
 /datum/martial_art/krav_maga/bump_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	if(A.a_intent == "harm" && A.m_intent=="run" && A.slowdown <= 0 && !A.l_hand && !A.r_hand && A.get_num_arms() == 2)
 		if(A.canmove && A.pulling != D && D.pulling != A && !D.buckled)
-			if(!(D.status_flags & CANPUSH) || (D.l_hand && D.l_hand:block_push) || (D.r_hand && D.r_hand:block_push))
+			if(!(D.status_flags & CANPUSH) || (D.l_hand && D.l_hand.block_push) || (D.r_hand && D.r_hand.block_push))
 				A.Stun(3)
 				A.Weaken(3)
 				A.adjustStaminaLoss(60)

--- a/code/modules/martial arts/krav_maga.dm
+++ b/code/modules/martial arts/krav_maga.dm
@@ -13,6 +13,7 @@
 	usr << "<b><i>You recall your Krav Maga teachings...</i></b>"
 	usr << "<span class='notice'>Robust Disarm</span>: Your disarms have no push chance, however, when you disarm someone the weapon is instantly put in your hands."
 	usr << "<span class='notice'>Pinning Down</span>: Pin your opponent down to immobilize them. Several ways to execute: reinforcing grab on top of someone will pin down. Attacking someone with a grab IN-HAND and disarm intent will also execute the move."
+	usr << "<span class='notice'>Heavy Tackle</span>: Running into somebody at full speed with empty hands on harm intent will cause you to tackle them to the ground, stunning them. This will stun you for a short amount of time and will heavily reduce your stamina."
 	usr << "<b><i>Most of your moves rely on intent cycling and grabs. Keep that in mind.</i></b>"
 
 /datum/martial_art/krav_maga/teach(mob/living/carbon/human/H, make_temporary)
@@ -161,6 +162,34 @@
 				G.force_down = 0
 			else
 				D.Weaken(3)
+	return 0
+
+/datum/martial_art/krav_maga/bump_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	if(A.a_intent == "harm" && A.m_intent=="run" && A.slowdown <= 0 && !A.l_hand && !A.r_hand && A.get_num_arms() == 2)
+		if(A.canmove && A.pulling != D && D.pulling != A && !D.buckled)
+			if(!(D.status_flags & CANPUSH) || (D.l_hand && D.l_hand:block_push) || (D.r_hand && D.r_hand:block_push))
+				A.Stun(3)
+				A.Weaken(3)
+				A.adjustStaminaLoss(60)
+				playsound(D, 'sound/effects/bang.ogg', 50, 1)
+				add_logs(A, D, "failed to tackle", addition="(Krav Maga)")
+				D.visible_message("<span class='danger'>[A] fails horribly at tackling [D] to the ground!</span>", \
+					"<span class='userdanger'>You block the tackle from [A]!</span>")
+			else
+				D.Stun(4)
+				D.Weaken(4)
+				A.Stun(2)
+				A.Weaken(2)
+				A.adjustStaminaLoss(60)
+				shake_camera(A, 3, 1)
+				shake_camera(D, 3, 1)
+				if(!A.stat && A.Adjacent(D))
+					A.forceMove(D.loc)
+				playsound(D, 'sound/effects/bang.ogg', 50, 1)
+				D.visible_message("<span class='danger'>[A] tackles [D] to the ground!</span>", \
+							"<span class='userdanger'>[A] tackles you to the ground!</span>")
+				add_logs(A, D, "tackled", addition="(Krav Maga)")
+			return 1
 	return 0
 
 /obj/item/clothing/gloves/krav_maga

--- a/code/modules/martial arts/martial.dm
+++ b/code/modules/martial arts/martial.dm
@@ -26,6 +26,9 @@
 /datum/martial_art/proc/tablepush_act(mob/living/carbon/human/A, mob/living/carbon/human/D) //Called when you tablepush someone
 	return 0
 
+/datum/martial_art/proc/bump_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
+	return 0
+
 /datum/martial_art/proc/add_to_streak(element,mob/living/carbon/human/A,mob/living/carbon/human/D)
 	if(istype(D) && D != current_target)
 		current_target = D

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -10,6 +10,7 @@
 	var/zombification = 0
 	var/numinfectedh = 0
 	var/noosed = 0
+	var/slowdown = 0
 
 /mob/living/carbon/human/dummy
 	real_name = "Test Dummy"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -978,6 +978,8 @@
 		if(H.status_flags & GOTTAGOREALLYFAST)
 			. -= 2
 
+	H.slowdown = .
+
 //////////////////
 // ATTACK PROCS //
 //////////////////

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -84,6 +84,12 @@ Sorry Giacom. Please don't be mad :(
 	if(now_pushing)
 		return 1
 
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		var/datum/martial_art/attacker_style = H.martial_art
+		if(attacker_style && attacker_style.bump_act(H,M))
+			return 1
+
 	//BubbleWrap: Should stop you pushing a restrained person out of the way
 	if(istype(M, /mob/living))
 		for(var/mob/MM in range(1, M))

--- a/html/changelogs/Kierany9 - HeavyTackle.yml
+++ b/html/changelogs/Kierany9 - HeavyTackle.yml
@@ -1,0 +1,7 @@
+author: Kierany9
+delete-after: True
+changes: 
+  - rscadd: "Security officers using Krav Maga can now perform the Heavy Tackle by running into their target on harm intent."
+  - tweak: "Tackling stuns your opponent but also stuns you briefly deals heavy stamina damage to you."
+  - tweak: "To perform a tackle, both your hands must be empty, you must have both your arms and you cannot have any slowdown."
+  - tweak: "Shields can block tackles and will cause you to stun yourself instead of your opponent."

--- a/html/changelogs/Kierany9 - HeavyTackle.yml
+++ b/html/changelogs/Kierany9 - HeavyTackle.yml
@@ -2,6 +2,6 @@ author: Kierany9
 delete-after: True
 changes: 
   - rscadd: "Security officers using Krav Maga can now perform the Heavy Tackle by running into their target on harm intent."
-  - tweak: "Tackling stuns your opponent but also stuns you briefly deals heavy stamina damage to you."
+  - tweak: "Tackling stuns your opponent but also stuns you briefly and deals heavy stamina damage to you."
   - tweak: "To perform a tackle, both your hands must be empty, you must have both your arms and you cannot have any slowdown."
   - tweak: "Shields can block tackles and will cause you to stun yourself instead of your opponent."


### PR DESCRIPTION
Quite possibly the stupidest PR I've ever made for something that nobody asked for:

- Security officers using Krav Maga can now perform the Heavy Tackle by running into their target on harm intent.
- Tackling stuns your opponent(4 ticks) but also stuns you briefly(2 ticks) and deals heavy stamina damage to you(60 stamina damage).
- To perform a tackle, both your hands must be empty, you must have both your arms and you cannot have any slowdown(this means that you can't have more than 40 damage of any type).
- Drugs do not affect your own stun and their timer will be reset if you tackle somebody
- Tackles make an extremely satisfying noise.
- Shields can block tackles and will cause you to stun yourself instead of your opponent.

![no fun allowed](http://i.imgur.com/ulWCU6i.gif)

(im sorry)