### PR TITLE
Last Resort and Adrenaline Sacs nerf

### DIFF
--- a/code/game/gamemodes/changeling/powers/adrenaline.dm
+++ b/code/game/gamemodes/changeling/powers/adrenaline.dm
@@ -12,6 +12,7 @@
 //Recover from stuns.
 /obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
 	if(cooldown > world.time)
+		user << "<span class='notice'>We must wait [round((cooldown - world.time)/10)] seconds before using our adrenaline sacs again.</span>"
 		return 0
 	user << "<span class='notice'>Energy rushes through us.[user.lying ? " We arise." : ""]</span>"
 	user.stat = 0

--- a/code/game/gamemodes/changeling/powers/adrenaline.dm
+++ b/code/game/gamemodes/changeling/powers/adrenaline.dm
@@ -6,10 +6,13 @@
 	evopoints_cost = 4
 	req_dna = 3 //Tier 2
 	req_human = 1
+	var/cooldown = 0
 	req_stat = UNCONSCIOUS
 
 //Recover from stuns.
 /obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
+	if(cooldown > world.time)
+		return 0
 	user << "<span class='notice'>Energy rushes through us.[user.lying ? " We arise." : ""]</span>"
 	user.stat = 0
 	user.SetParalysis(0)
@@ -21,4 +24,5 @@
 	user.reagents.add_reagent("changelingAdrenaline2", 2) //For a really quick burst of speed
 	user.adjustStaminaLoss(-75)
 	feedback_add_details("changeling_powers","UNS")
+	cooldown = world.time + 100
 	return 1

--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -25,7 +25,7 @@
 			I.Remove(user, 1)
 
 	for(var/mob/living/carbon/human/H in view(1,user))
-		if(!target.check_eye_prot())
+		if(!H.check_eye_prot())
 			H << "<span class='userdanger'>You are blinded by a shower of blood!</span>"
 			H.apply_effect(3, PARALYZE)
 			H.eye_blurry = 20

--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -24,14 +24,14 @@
 		for(var/obj/item/organ/internal/I in organs)
 			I.Remove(user, 1)
 
-	for(var/mob/living/carbon/human/H in view(2,user))
+	for(var/mob/living/carbon/human/H in view(1,user))
 		if(!target.check_eye_prot())
 			H << "<span class='userdanger'>You are blinded by a shower of blood!</span>"
 			H.apply_effect(2, PARALYZE)
 			H.eye_blurry = 20
 			H.eye_stat += 10
 			H.confused += 5
-	for(var/mob/living/silicon/S in view(2,user))
+	for(var/mob/living/silicon/S in view(1,user))
 		S << "<span class='userdanger'>Your sensors are disabled by a shower of blood!</span>"
 		S.Weaken(3)
 	var/turf = get_turf(user)

--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -24,13 +24,14 @@
 		for(var/obj/item/organ/internal/I in organs)
 			I.Remove(user, 1)
 
-	for(var/mob/living/carbon/human/H in view(7,user))
-		H << "<span class='userdanger'>You are blinded by a shower of blood!</span>"
-		H.apply_effect(5, PARALYZE)
-		H.eye_blurry = 20
-		H.eye_stat += 10
-		H.confused += 10
-	for(var/mob/living/silicon/S in view(7,user))
+	for(var/mob/living/carbon/human/H in view(2,user))
+		if(!target.check_eye_prot())
+			H << "<span class='userdanger'>You are blinded by a shower of blood!</span>"
+			H.apply_effect(2, PARALYZE)
+			H.eye_blurry = 20
+			H.eye_stat += 10
+			H.confused += 5
+	for(var/mob/living/silicon/S in view(2,user))
 		S << "<span class='userdanger'>Your sensors are disabled by a shower of blood!</span>"
 		S.Weaken(3)
 	var/turf = get_turf(user)

--- a/code/game/gamemodes/changeling/powers/headcrab.dm
+++ b/code/game/gamemodes/changeling/powers/headcrab.dm
@@ -27,7 +27,7 @@
 	for(var/mob/living/carbon/human/H in view(1,user))
 		if(!target.check_eye_prot())
 			H << "<span class='userdanger'>You are blinded by a shower of blood!</span>"
-			H.apply_effect(2, PARALYZE)
+			H.apply_effect(3, PARALYZE)
 			H.eye_blurry = 20
 			H.eye_stat += 10
 			H.confused += 5


### PR DESCRIPTION
DNM, no logs and I haven't tested this locally yet.

>wearing a space helmet, gas mask and sunglasses
>get blinded, disoriented and knocked out by a shower of blood along with everybody else in the room

whose idea was this?

- Adds a 10 second cooldown to adrenaline sacs. The injected chemicals already work like automatic adrenals after the chemistry revamp, if you manage to get stunned within 4 ticks of using adrenaline, then you shouldn't be getting up from that.
- Last resort no longer blinds you if you have eye protection.
- Reduces the range of last resort's blast from seven tiles to one tile becaus that's how far the blood actually goes and because no matter how you look at it a room-based unblockable AOE stun is basically a guaranteed escape.
- Reduces the length of paralysis and confusion on last resort.