### PR TITLE
Stomping + Melee Combat Tweaks

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -164,6 +164,7 @@ BLIND     // can't see anything
 	desc = "Comfortable-looking shoes."
 	gender = PLURAL //Carn: for grammarically correct text-parsing
 	var/chained = 0
+	var/stomp = 0 //0 for regular shoes, 1 for heavy shoes like jackboots and 2 for magboots
 
 	body_parts_covered = FEET
 	slot_flags = SLOT_FEET

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -57,4 +57,4 @@
 	icon_state = "syndiemag0"
 	magboot_state = "syndiemag"
 	origin_tech = "magnets=2,syndicate=3"
-	slowdown_active = SHOES_SLOWDOWN
+	slowdown_active = 1

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -10,7 +10,7 @@
 	put_on_delay = 70
 	burn_state = -1 //Won't burn in fires
 	origin_tech = "magnets=2"
-	stomp = 2
+	stomp = 1
 
 /obj/item/clothing/shoes/magboots/verb/toggle()
 	set name = "Toggle Magboots"
@@ -25,9 +25,11 @@
 	if(src.magpulse)
 		src.flags &= ~NOSLIP
 		src.slowdown = SHOES_SLOWDOWN
+		stomp = 1
 	else
 		src.flags |= NOSLIP
 		src.slowdown = slowdown_active
+		stomp = 2
 	magpulse = !magpulse
 	icon_state = "[magboot_state][magpulse]"
 	user << "<span class='notice'>You [magpulse ? "enable" : "disable"] the mag-pulse traction system.</span>"

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -57,3 +57,4 @@
 	icon_state = "syndiemag0"
 	magboot_state = "syndiemag"
 	origin_tech = "magnets=2,syndicate=3"
+	slowdown_active = SHOES_SLOWDOWN

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -10,6 +10,7 @@
 	put_on_delay = 70
 	burn_state = -1 //Won't burn in fires
 	origin_tech = "magnets=2"
+	stomp = 2
 
 /obj/item/clothing/shoes/magboots/verb/toggle()
 	set name = "Toggle Magboots"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -42,6 +42,7 @@
 	armor = list(melee = 25, bullet = 25, laser = 25, energy = 25, bomb = 50, bio = 10, rad = 0)
 	strip_delay = 70
 	burn_state = -1 //Won't burn in fires
+	stomp = 1
 
 /obj/item/clothing/shoes/combat/swat //overpowered boots for death squads
 	name = "\improper SWAT boots"
@@ -49,6 +50,7 @@
 	permeability_coefficient = 0.01
 	flags = NOSLIP
 	armor = list(melee = 40, bullet = 30, laser = 25, energy = 25, bomb = 50, bio = 30, rad = 30)
+	stomp = 1
 
 /obj/item/clothing/shoes/combat/camo //camo boots for ruskies
 	name = "camoflage combat boots"
@@ -58,6 +60,7 @@
 	permeability_coefficient = 0.01
 	flags = NOSLIP
 	armor = list(melee = 50, bullet = 60, laser = 50, energy = 30, bomb = 20, bio = 10, rad = 15)
+	stomp = 1
 
 /obj/item/clothing/shoes/sandal
 	desc = "A pair of rather plain, wooden sandals."
@@ -133,6 +136,7 @@
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
 	burn_state = -1 //Won't burn in fires
+	stomp = 1
 
 /obj/item/clothing/shoes/winterboots
 	name = "winter boots"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -50,7 +50,6 @@
 	permeability_coefficient = 0.01
 	flags = NOSLIP
 	armor = list(melee = 40, bullet = 30, laser = 25, energy = 25, bomb = 50, bio = 30, rad = 30)
-	stomp = 1
 
 /obj/item/clothing/shoes/combat/camo //camo boots for ruskies
 	name = "camoflage combat boots"
@@ -60,7 +59,6 @@
 	permeability_coefficient = 0.01
 	flags = NOSLIP
 	armor = list(melee = 50, bullet = 60, laser = 50, energy = 30, bomb = 20, bio = 10, rad = 15)
-	stomp = 1
 
 /obj/item/clothing/shoes/sandal
 	desc = "A pair of rather plain, wooden sandals."

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1039,7 +1039,7 @@
 							if(do_mob(M, H, 40) && H.lying)
 								playsound(H, 'sound/misc/splort.ogg', 70, 1)
 								H.emote("scream")
-								H.apply_damage(30, BRUTE, affecting, armor_block)
+								H.apply_damage(45, BRUTE, affecting, armor_block)
 								H.visible_message("<span class='danger'>[M] has [atk_verb]ed [H] with their [S.name]!</span>", \
 												"<span class='userdanger'>[M] has [atk_verb]ed [H] with their [S.name]!</span>")
 							else
@@ -1232,7 +1232,7 @@
 	var/Iforce = I.force //to avoid runtimes on the forcesay checks at the bottom. Some items might delete themselves if you drop them. (stunning yourself, ninja swords)
 	var/dmgtype = STAMINA
 	if(H.lying)
-		dmgtype = BRUTE
+		dmgtype = I.damtype
 	var/dmgcheck = apply_damage((1-I.stamina_percentage)*I.force, I.damtype, affecting, armor_block, H)
 	var/staminadmgcheck = apply_damage(I.stamina_percentage*I.force, dmgtype, affecting, armor_block, H)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1019,17 +1019,38 @@
 			if(attacker_style && attacker_style.harm_act(M,H))
 				return 1
 			else
-				M.do_attack_animation(H)
-
 				var/atk_verb = M.dna.species.attack_verb
-				if(H.lying)
-					atk_verb = "kick"
-
 				var/hitcheck = rand(0, 9)
-				var/damage = pick(0.5, 1, 1.5, 2) + M.dna.species.punchmod
-
+				var/damage = rand(0,4) + pick(0.5, 1) + M.dna.species.punchmod
+				var/dmgtype = STAMINA
 				var/obj/item/organ/limb/affecting = H.getrandomorgan(M.zone_sel.selecting)
 				var/armor_block = H.run_armor_check(affecting, "melee")
+				
+				if(H.lying)
+					atk_verb = "kick"
+					if(M.shoes)
+						var/obj/item/clothing/shoes/S = M.shoes
+						if(S.stomp > 0)
+							atk_verb = "stomp"
+							dmgtype = BRUTE
+						if(S.stomp == 2)
+							M << "<span class='danger'>You raise your [S.name] over [H], ready to stomp them.</span>"
+							M.changeNext_move(45)
+							if(do_mob(M, H, 40) && H.lying)
+								playsound(H, 'sound/misc/splort.ogg', 70, 1)
+								H.emote("scream")
+								H.apply_damage(30, BRUTE, affecting, armor_block)
+								H.visible_message("<span class='danger'>[M] has [atk_verb]ed [H] with their [S.name]!</span>", \
+												"<span class='userdanger'>[M] has [atk_verb]ed [H] with their [S.name]!</span>")
+							else
+								H.visible_message("<span class='danger'>[M] has attempted to [atk_verb] [H] with [S]!</span>")
+								H.changeNext_move(CLICK_CD_MELEE)
+							playsound(H, 'sound/effects/meteorimpact.ogg', 70, 1)
+							M.do_attack_animation(H)
+							add_logs(M, H, "stomped")
+							return 1
+
+				M.do_attack_animation(H)
 				var/dmgcheck = apply_damage(damage, BRUTE, affecting, armor_block, H)
 
 				if(hitcheck == 0 || !dmgcheck)
@@ -1038,7 +1059,7 @@
 					return 0
 
 				playsound(H.loc, get_sfx(M.dna.species.attack_sound), 25, 1, -1)
-				H.apply_damage(damage*3+2, STAMINA, affecting, armor_block)
+				H.apply_damage(damage+2, dmgtype, affecting, armor_block)
 				H.visible_message("<span class='danger'>[M] has [atk_verb]ed [H]!</span>", \
 								"<span class='userdanger'>[M] has [atk_verb]ed [H]!</span>")
 
@@ -1209,8 +1230,11 @@
 
 	var/armor_block = H.run_armor_check(affecting, "melee", "<span class='notice'>Your armor has protected your [hit_area].</span>", "<span class='notice'>Your armor has softened a hit to your [hit_area].</span>",I.armour_penetration)
 	var/Iforce = I.force //to avoid runtimes on the forcesay checks at the bottom. Some items might delete themselves if you drop them. (stunning yourself, ninja swords)
+	var/dmgtype = STAMINA
+	if(H.lying)
+		dmgtype = BRUTE
 	var/dmgcheck = apply_damage((1-I.stamina_percentage)*I.force, I.damtype, affecting, armor_block, H)
-	var/staminadmgcheck = apply_damage(I.stamina_percentage*I.force, STAMINA, affecting, armor_block, H)
+	var/staminadmgcheck = apply_damage(I.stamina_percentage*I.force, dmgtype, affecting, armor_block, H)
 
 	if(!dmgcheck && !staminadmgcheck && I.force != 0 || !affecting) //Something went wrong. Maybe the limb is missing?
 		H.visible_message("<span class='danger'>[user] has attempted to attack [H] with [I]!</span>", \

--- a/html/changelogs/Kierany9 - MediumStyle.yml
+++ b/html/changelogs/Kierany9 - MediumStyle.yml
@@ -7,3 +7,4 @@ changes:
   - tweak: "Fists now deal less stamina damage and more brute damage."
   - rscadd: "You can now stomp people if you are wearing boots and they are prone. Stomping deals full brute damage instead of a mix of brute and stamina."
   - rscadd: "Stomping with magboots that are on will perform a special attack that takes four seconds to wind up but deals a whopping 45 brute damage."
+  - tweak: "Syndciate magboots no longer slow you down when active."

--- a/html/changelogs/Kierany9 - MediumStyle.yml
+++ b/html/changelogs/Kierany9 - MediumStyle.yml
@@ -1,0 +1,9 @@
+author: Kierany9
+
+delete-after: True
+
+changes: 
+  - experiment: "Weapons deal full brute damage on prone targets and do not deal any stamina damage."
+  - tweak: "Fists now deal less stamina damage and more brute damage."
+  - rscadd: "You can now stomp people if you are wearing boots and they are prone. Stomping deals full brute damage instead of a mix of brute and stamina."
+  - rscadd: "Stomping with magboots will perform a special attack that takes four seconds to wind up but deals a whopping 45 brute damage."

--- a/html/changelogs/Kierany9 - MediumStyle.yml
+++ b/html/changelogs/Kierany9 - MediumStyle.yml
@@ -7,4 +7,4 @@ changes:
   - tweak: "Fists now deal less stamina damage and more brute damage."
   - rscadd: "You can now stomp people if you are wearing boots and they are prone. Stomping deals full brute damage instead of a mix of brute and stamina."
   - rscadd: "Stomping with magboots that are on will perform a special attack that takes four seconds to wind up but deals a whopping 45 brute damage."
-  - tweak: "Syndciate magboots no longer slow you down when active."
+  - tweak: "Syndciate magboots have reduced slowdown when active."

--- a/html/changelogs/Kierany9 - MediumStyle.yml
+++ b/html/changelogs/Kierany9 - MediumStyle.yml
@@ -6,4 +6,4 @@ changes:
   - experiment: "Weapons deal full brute damage on prone targets and do not deal any stamina damage."
   - tweak: "Fists now deal less stamina damage and more brute damage."
   - rscadd: "You can now stomp people if you are wearing boots and they are prone. Stomping deals full brute damage instead of a mix of brute and stamina."
-  - rscadd: "Stomping with magboots will perform a special attack that takes four seconds to wind up but deals a whopping 45 brute damage."
+  - rscadd: "Stomping with magboots that are on will perform a special attack that takes four seconds to wind up but deals a whopping 45 brute damage."


### PR DESCRIPTION
### Features
- Adds Stomping. Jackboots, Magboots and Combat boots deal extra brute damage on downed targets and when active, Magboots can perform a windup attack that deals 45 brute as long as the target stays down for four seconds.

### Tweaks
- Melee weapons do not deal stamina damage on prone opponents and instead deal the full amount of brute damage.
- Fists deal more brute damage and less stamina damage (0.5 to 5 brute and 2.5 to 7.5 stamina instead of 0.5 to 2 brute and 3.5 to 9 stamina).
- Syndicate Magboots have one less slowdown when active (2 -> 1)