### PR TITLE
Minor bugfixes and balancing

### DIFF
--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -55,7 +55,7 @@
 /obj/item/projectile/bullet/sniper/on_hit(atom/target, blocked = 0, hit_zone)
 	if((blocked != 100) && (!ismob(target) && breakthings))
 		target.ex_act(rand(1,2))
-	if((blocked != 100) && ishuman(target) && (hit_zone != ("chest" || "head")) && breakthings)
+	if((blocked != 100) && ishuman(target) && hit_zone != "chest" && hit_zone != "head" && breakthings)
 		var/mob/living/carbon/human/H = target
 		var/obj/item/organ/limb/O = H.get_organ(hit_zone)
 		O.dismember()

--- a/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
@@ -191,7 +191,7 @@
 			M.drop_item()
 	stun_timer = max(0, stun_timer - 0.5)
 	..()
-	M.adjustToxLoss(1)
+	M.adjustToxLoss(1.3)
 	M.adjustBrainLoss(pick(0.5, 0.6, 0.7, 0.8, 0.9, 1))
 	return
 

--- a/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Drug-Reagents.dm
@@ -168,7 +168,7 @@
 	if(prob(5))
 		M << "<span class='notice'>[high_message]</span>"
 	M.Jitter(2)
-	M.adjustToxLoss(0.6*REM)
+	M.adjustToxLoss(0.3*REM)
 	M.adjustStaminaLoss(-3)
 	M.sleeping = max(0,M.sleeping - 2)
 	if(prob(5))
@@ -424,12 +424,13 @@
 	description = "Amps you up and gets you going, fixes all stamina damage you might have but can cause toxin and oxygen damage.."
 	reagent_state = LIQUID
 	color = "#60A584" // rgb: 96, 165, 132
+	speedboost = VERY_FAST + FAST
 
 /datum/reagent/drug/aranesp/on_mob_life(mob/living/M)
 	var/high_message = pick("You feel amped up.", "You feel ready.", "You feel like you can push it to the limit.")
 	if(prob(5))
 		M << "<span class='notice'>[high_message]</span>"
-	M.adjustStaminaLoss(-18)
+	M.setStaminaLoss(0)
 	M.adjustToxLoss(0.5)
 	if(prob(50))
 		M.losebreath++

--- a/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Medicine-Reagents.dm
@@ -468,7 +468,7 @@
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30
 	addiction_threshold = 30
-	stun_threshold = 6
+	stun_threshold = 8
 	stun_resist = 4
 	speedboost = FAST
 
@@ -573,17 +573,15 @@
 		N.hal_screwyhud = 5
 	for(var/datum/reagent/R in M.reagents.reagent_list)
 		R.stun_timer = max(0, stun_timer - 0.5)
-	if(current_cycle >= 10)
-		M.drowsyness += 1
-		if(M.health <= 30)
-			M.sleeping += 1
+	if(current_cycle >= 10 && M.health <= 30)
+		M.sleeping += 1
 	..()
 	return
 
 /datum/reagent/medicine/morphine/on_mob_delete(mob/living/M)
 	M.drowsyness += 10
 	if(M.health <= 30)
-		M.sleeping += 5
+		M.sleeping += 10
 	if(iscarbon(M))
 		var/mob/living/carbon/N = M
 		N.hal_screwyhud = 0

--- a/html/changelogs/Kierany9 - Bugfixes5.yml
+++ b/html/changelogs/Kierany9 - Bugfixes5.yml
@@ -2,6 +2,7 @@ author: Kierany9
 delete-after: True
 changes: 
   - bugfix: "Fixed Sniper Rifles being able to dismember heads and torsos."
+  - tweak: "Increased the time it takes for Ephedrine's antistun to activate by 33%."
   - tweak: "Removed morphine-induced drowsiness during use. The drowsiness after it runs out still remains."
   - tweak: "Aranesp now boosts your speed more than any other drugs and fully nullifies all stamina damage just like Heroin."
   - tweak: "Meth's toxin damage has been halved. Overdoses do the same amount of damage as before."

--- a/html/changelogs/Kierany9 - Bugfixes5.yml
+++ b/html/changelogs/Kierany9 - Bugfixes5.yml
@@ -1,0 +1,7 @@
+author: Kierany9
+delete-after: True
+changes: 
+  - bugfix: "Fixed Sniper Rifles being able to dismember heads and torsos."
+  - tweak: "Removed morphine-induced drowsiness during use. The drowsiness after it runs out still remains."
+  - tweak: "Aranesp now boosts your speed more than any other drugs and fully nullifies all stamina damage just like Heroin."
+  - tweak: "Meth's toxin damage has been halved. Overdoses do the same amount of damage as before."


### PR DESCRIPTION
### Fixed Sniper Rifles being able to dismember heads and torsos.

This was never supposed to be a thing. Oops.

### Removed morphine-induced drowsiness during use. The drowsiness after it runs out still remains.

Useless feature I added to try and balance it out but in practise it just makes morphine annoying to use.

### Increased the time it takes for Ephedrine to take effect from 6 ticks to 8

these ez antistuns are a tad too good.

### Aranesp now boosts your speed more than any other drug and fully nullifies all stamina damage just like Heroin.

If your lethal drug is going to have any positive effects, please don't make them useless. I accidentally overshadowed it with Heroin so here's something to redeem that.

### Meth's toxin damage has been halved. Overdoses do the same amount of damage as before.