### PR TITLE
Removes second stun resist from antistuns

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -133,10 +133,7 @@
 		metabolization_rate = 2 * initial(metabolization_rate)
 		for(var/datum/reagent/R in M.reagents.reagent_list)
 			if(R.stun_timer >= R.stun_threshold)
-				if(R.stun_timer >= R.stun_threshold + 3)
-					R.stun_timer = R.stun_threshold - 1
-				else
-					R.stun_timer = 0
+				R.stun_timer = 0
 				M.AdjustParalysis(-R.stun_resist)
 				M.AdjustStunned(-R.stun_resist)
 				M.AdjustWeakened(-R.stun_resist)

--- a/html/changelogs/Kierany9 - stuns.yml
+++ b/html/changelogs/Kierany9 - stuns.yml
@@ -1,0 +1,12 @@
+author: Kierany9
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscdel: "Anti-stun chemicals no longer grant multiple immediate stun resists if you wait a short time after chem activation."


### PR DESCRIPTION
Basically, after I reworked antistun chemicals, they allowed you to get up from a stun immediately after X ticks of not being stunned. However, after initial testing by our local powergaming expert showed that this was somewhat underpowered, I added a second stun resist that would allow you to resist stuns immediately if you spent 3 ticks unstunned after the timer hit X, _and said stun resist would only set the timer back to X, meaning you could ignore taser-strength stuns every three seconds regardless of the effectiveness of the chemical_. I think you can all see what went wrong here and why I'm removing this feature.
