### PR TITLE
[Cargo + RnD] Autolathe Buff

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -539,6 +539,78 @@
 	build_path = /obj/item/ammo_box/c9mm
 	category = list("hacked", "Security")
 
+/datum/design/a40mm
+	name = "Ammo box (40mm HE grenades)"
+	id = "a40mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 40000)
+	build_path = /obj/item/ammo_box/a40mm
+	category = list("hacked", "Security")
+
+/datum/design/a762x39
+	name = "Ammo box (7.62x39)"
+	id = "a762x39"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_casing/a762x39
+	category = list("hacked", "Security")
+
+/datum/design/rubber762
+	name = "Ammo box (.762x54)"
+	id = "a762rubber"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/a762rubber
+	category = list("hacked", "Security")
+
+/datum/design/m12g
+	name = "Magazine (12g slugs)"
+	id = "m12g"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_casing/shotgun
+	category = list("hacked", "Security")
+
+/datum/design/xmg80
+	name = "Magazine (6.8x43mm Caseless)"
+	id = "xmg80"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_casing/caseless/a68
+	category = list("hacked", "Security")
+
+/datum/design/m556
+	name = "Magazine (5.56mm)"
+	id = "m556"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/magazine/m556
+	category = list("hacked", "Security")
+
+/datum/design/m762
+	name = "Magazine (7.62mm)"
+	id = "m762"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/magazine/m762
+	category = list("hacked", "Security")
+
+/datum/design/m50
+	name = "Magazine (.50 AE)"
+	id = "m50"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/magazine/m50
+	category = list("hacked", "Security")
+
+/datum/design/m44
+	name = "Magazine (.44 AMP)"
+	id = "m44"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/magazine/m44
+	category = list("hacked", "Security")
+
 /datum/design/spraycan
 	name = "Spraycan"
 	id = "spraycan"
@@ -578,14 +650,6 @@
 	materials = list(MAT_METAL = 150, MAT_GLASS = 150)
 	build_path = /obj/item/device/geiger_counter
 	category = list("initial", "Tools")
-
-/datum/design/rubber762
-	name = "Ammo box (.762x54)"
-	id = "a762rubber"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_box/a762rubber
-	category = list("hacked", "Security")
 
 /datum/design/icepick
 	name = "Ice Pick"

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -552,7 +552,7 @@
 	id = "a762x39"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_casing/a762x39
+	build_path = /obj/item/ammo_box/a762x39
 	category = list("hacked", "Security")
 
 /datum/design/rubber762
@@ -568,7 +568,7 @@
 	id = "m12g"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_casing/shotgun
+	build_path = /obj/item/ammo_box/magazine/m12g
 	category = list("hacked", "Security")
 
 /datum/design/xmg80
@@ -576,7 +576,7 @@
 	id = "xmg80"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/ammo_casing/caseless/a68
+	build_path = /obj/item/ammo_box/magazine/xmg80
 	category = list("hacked", "Security")
 
 /datum/design/m556

--- a/html/changelogs/Swagile - Autolathe-Ammo.yml
+++ b/html/changelogs/Swagile - Autolathe-Ammo.yml
@@ -1,0 +1,38 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Swagile
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - experiment: "Adds new ammo types to autolathe which buffs Summon Guns events."
+  - experiment: "Stealth buffs RnD due to some ammo having tech origins."
+  - experiment: "Preparation for a possible future update to cargo."


### PR DESCRIPTION
~ Adds new ammo types to autolathe that are exclusively to summon guns and admin events.
~ Boosts RnD due to combat tech levels being in ammo.
~ Possible addition to a future cargo update I am planning; this is just prep. No, I am not adding SAW's to cargo.

Some of the ammo comes in "magazines" instead of actual ammo boxes but that is just how ammo works from the code ive looked at while doing this. This is a simple change code wise, but gameplay wise it changes up RnD a lot since speed running combat tech is now easier and it allows you to print ammo for most summon guns weapons. 

This further increases the chaos of summon gun wizard rounds as everyone with a ballistic makes a mad dash for cargo. This is also a prep for a future update ive been thinking of to cargo that adds extremely expensive crates in the 500 + point margin (suggestion on forums made by another user) but in return you get special crates like nanotrasen assault rifle crates. This is in the future, however, and hinges partly on this pull request being accepted.