### PR TITLE
More realistic hallucinations

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -805,17 +805,19 @@
 			H.staminas.icon_state = "stamina6"
 		else if(H.stunned || H.weakened)
 			H.staminas.icon_state = "stamina6"
-		else if(H.hal_screwyhud == 5)
-			H.staminas.icon_state = "stamina0"
 		else
-			switch(H.health - H.staminaloss)
-				if(100 to INFINITY)     H.staminas.icon_state = "stamina0"
-				if(80 to 100)           H.staminas.icon_state = "stamina1"
-				if(60 to 80)            H.staminas.icon_state = "stamina2"
-				if(40 to 60)            H.staminas.icon_state = "stamina3"
-				if(20 to 40)            H.staminas.icon_state = "stamina4"
-				if(0 to 20)             H.staminas.icon_state = "stamina5"
-				else                    H.staminas.icon_state = "stamina6"
+			switch(H.hal_screwyhud)
+				if(1 to 2)	H.staminas.icon_state = "stamina0"
+				if(5)	H.staminas.icon_state = "stamina6"
+				else
+					switch(H.health - H.staminaloss)
+						if(100 to INFINITY)     H.staminas.icon_state = "stamina0"
+						if(80 to 100)           H.staminas.icon_state = "stamina1"
+						if(60 to 80)            H.staminas.icon_state = "stamina2"
+						if(40 to 60)            H.staminas.icon_state = "stamina3"
+						if(20 to 40)            H.staminas.icon_state = "stamina4"
+						if(0 to 20)             H.staminas.icon_state = "stamina5"
+						else                    H.staminas.icon_state = "stamina6"
 
 	if(H.healthdoll)
 		H.healthdoll.overlays.Cut()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -805,6 +805,8 @@
 			H.staminas.icon_state = "stamina6"
 		else if(H.stunned || H.weakened)
 			H.staminas.icon_state = "stamina6"
+		else if(H.hal_screwyhud == 5)
+			H.staminas.icon_state = "stamina0"
 		else
 			switch(H.health - H.staminaloss)
 				if(100 to INFINITY)     H.staminas.icon_state = "stamina0"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -807,8 +807,8 @@
 			H.staminas.icon_state = "stamina6"
 		else
 			switch(H.hal_screwyhud)
-				if(1 to 2)	H.staminas.icon_state = "stamina0"
-				if(5)	H.staminas.icon_state = "stamina6"
+				if(1 to 2)	H.staminas.icon_state = "stamina6"
+				if(5)	H.staminas.icon_state = "stamina0"
 				else
 					switch(H.health - H.staminaloss)
 						if(100 to INFINITY)     H.staminas.icon_state = "stamina0"

--- a/html/changelogs/Kierany9 - Hallucinations.yml
+++ b/html/changelogs/Kierany9 - Hallucinations.yml
@@ -1,0 +1,4 @@
+author: Kierany9
+delete-after: True
+changes:
+  - bugfix: "Made certain health-related hallucinations more convincing."


### PR DESCRIPTION
The max health hallucination now makes your stamina appear full as well. This also prevents you from gauging your HP from your stamina bar while using Morphine, Heroin or Miner's Salve.