### PR TITLE
Replaces the roman shield in the autodrobe with a replica one.

### DIFF
--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -951,7 +951,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 					/obj/item/clothing/suit/hooded/ian_costume = 1,
 					/obj/item/clothing/under/dio = 1, /obj/item/clothing/gloves/color/dio = 1, /obj/item/clothing/head/dio = 1, /obj/item/clothing/suit/dio = 1, /obj/item/clothing/shoes/dio = 1)
 	contraband = list(/obj/item/clothing/suit/judgerobe = 1,/obj/item/clothing/head/powdered_wig = 1,/obj/item/weapon/gun/magic/wand = 2,/obj/item/clothing/glasses/sunglasses/garb = 2)
-	premium = list(/obj/item/clothing/suit/hgpirate = 2, /obj/item/clothing/head/hgpiratecap = 2, /obj/item/clothing/head/helmet/roman = 1, /obj/item/clothing/head/helmet/roman/legionaire = 1, /obj/item/clothing/under/roman = 1, /obj/item/clothing/shoes/roman = 1, /obj/item/weapon/shield/roman = 1, /obj/item/clothing/under/pmc = 1)
+	premium = list(/obj/item/clothing/suit/hgpirate = 2, /obj/item/clothing/head/hgpiratecap = 2, /obj/item/clothing/head/helmet/roman = 1, /obj/item/clothing/head/helmet/roman/legionaire = 1, /obj/item/clothing/under/roman = 1, /obj/item/clothing/shoes/roman = 1, /obj/item/weapon/shield/roman/replica = 1, /obj/item/clothing/under/pmc = 1)
 	refill_canister = /obj/item/weapon/vending_refill/autodrobe
 
 /obj/machinery/vending/dinnerware

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -23,7 +23,7 @@
 
 /obj/item/weapon/shield/roman/replica
 	name = "roman shield"
-	desc = "Bears an inscription on the inside: <i>\Romanes venio domus\"</i>. Feels flimsy."
+	desc = "Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>. Feels flimsy."
 	icon_state = "roman_shield"
 	item_state = "roman_shield"
 	slot_flags = SLOT_BACK

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -28,7 +28,7 @@
 	item_state = "roman_shield"
 	slot_flags = SLOT_BACK
 	force = 8
-	stamina percentage = 0.75
+	stamina_percentage = 0.75
 	throwforce = 5
 	throw_speed = 2
 	throw_range = 3

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -25,7 +25,7 @@
 	name = "roman shield"
 	desc = "Bears an inscription on the inside: <i>\Romanes venio domus\"</i>. Feels flimsy."
 	icon_state = "roman_shield"
-	item_state = "roman_shield
+	item_state = "roman_shield"
 	slot_flags = SLOT_BACK
 	force = 8
 	stamina percentage = 0.75

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -24,17 +24,6 @@
 /obj/item/weapon/shield/roman/replica
 	name = "roman shield"
 	desc = "Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>. Feels flimsy."
-	icon_state = "roman_shield"
-	item_state = "roman_shield"
-	slot_flags = SLOT_BACK
-	force = 8
-	stamina_percentage = 0.75
-	throwforce = 5
-	throw_speed = 2
-	throw_range = 3
-	w_class = 4
-	materials = list(MAT_GLASS=7500, MAT_METAL=1000)
-	origin_tech = "materials=2"
 	block_chance = list(melee = 20, bullet = 0, laser = 0, energy = 0) //It's a replica, it won't block anything but some melee hits because its cheap plastic.
 
 //Deployable shields, woo!

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -21,6 +21,22 @@
 	origin_tech = "materials=2"
 	block_chance = list(melee = 60, bullet = 50, laser = 50, energy = 50) //Skeleton-exclusive atm, sooo
 
+/obj/item/weapon/shield/roman/replica
+	name = "roman shield"
+	desc = "Bears an inscription on the inside: <i>\Romanes venio domus\"</i>. Feels flimsy."
+	icon_state = "roman_shield"
+	item_state = "roman_shield
+	slot_flags = SLOT_BACK
+	force = 8
+	stamina percentage = 0.75
+	throwforce = 5
+	throw_speed = 2
+	throw_range = 3
+	w_class = 4
+	materials = list(MAT_GLASS=7500, MAT_METAL=1000)
+	origin_tech = "materials=2"
+	block_chance = list(melee = 20, bullet = 0, laser = 0, energy = 0) //It's a replica, it won't block anything but some melee hits because its cheap plastic.
+
 //Deployable shields, woo!
 //Basically "defensive stance" for shields like riot, etc.
 /obj/item/weapon/shield/deployable

--- a/html/changelogs/Spacedong - replicaromanshield.yml
+++ b/html/changelogs/Spacedong - replicaromanshield.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Spacedong
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "The roman shield found in the Autodrobe is now a replica one. This means that it won't block anything short of a couple melee hits if you're lucky, mainly because its made of cheap plastic and not the real thing."


### PR DESCRIPTION
The roman shield once found in the autodrobe is now a replica made of cheap plastic, meaning it will only block some melee hits if you're lucky, and won't block any ranged sources of damage. Skeletons still get the real deal however. Fixes issue #3039