### PR TITLE
Medical doctors' lockers now start with regular latex gloves instead of nitrile gloves.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -46,7 +46,7 @@
 	..()
 	new /obj/item/device/radio/headset/headset_med(src)
 	new /obj/item/weapon/defibrillator/loaded(src)
-	new /obj/item/clothing/gloves/color/latex/nitrile(src)
+	new /obj/item/clothing/gloves/color/latex(src)
 	new /obj/item/weapon/storage/belt/medical(src)
 	new /obj/item/clothing/glasses/hud/health(src)
 	return

--- a/html/changelogs/Spacedong - latex.yml
+++ b/html/changelogs/Spacedong - latex.yml
@@ -33,4 +33,4 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - tweak: "Medical doctor's lockers now start with regular latex gloves instead of nitrile gloves. CMO's locker still starts with nitrile gloves however."
+  - tweak: "Medical doctors' lockers now start with regular latex gloves instead of nitrile gloves. CMO's locker still starts with nitrile gloves however."

--- a/html/changelogs/Spacedong - latex.yml
+++ b/html/changelogs/Spacedong - latex.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Spacedong
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Medical doctor's lockers now start with regular latex gloves instead of nitrile gloves. CMO's locker still starts with nitrile gloves however."


### PR DESCRIPTION
Latex gloves are weaker than nitrile gloves in concealing fingerprints and are of lower quality than the nitrile gloves owned by CMO. Don't know why this was changed when nitrile gloves were added, but it used to be this way anyway.