### PR TITLE
Gang Tweaks, Traitorling Playercount and Maximum Playercounts

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -670,6 +670,6 @@
 		if(probabilities[M.config_tag]<=0)
 			qdel(M)
 			continue
-		if(M.required_players <= crew)
+		if(M.required_players <= crew && (!M.max_players || M.max_players >= crew))
 			runnable_modes[M] = probabilities[M.config_tag]
 	return runnable_modes

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -655,7 +655,7 @@
 		if(probabilities[M.config_tag]<=0)
 			qdel(M)
 			continue
-		if(M.can_start())
+		if(M.can_start() == 1)
 			runnable_modes[M] = probabilities[M.config_tag]
 			//world << "DEBUG: runnable_mode\[[runnable_modes.len]\] = [M.config_tag]"
 	return runnable_modes

--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -25,8 +25,7 @@
 	world << "<b>Crew</b> - don't get abducted and stop the abductors."
 
 /datum/game_mode/abduction/pre_setup()
-	// abductor_teams = max(1, min(max_teams,round(num_players()/config.abductor_scaling_coeff))) Old scaling
-	abductor_teams = max(1, min(max_teams,round(max_teams*num_players()/max_players))) // Scaling based off of max players
+	abductor_teams = max(1, min(max_teams,round(num_players()/config.abductor_scaling_coeff)))
 	var/possible_teams = max(1,round(antag_candidates.len / 2))
 	abductor_teams = min(abductor_teams,possible_teams)
 

--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -9,6 +9,7 @@
 	antag_flag = ROLE_ABDUCTOR
 	recommended_enemies = 2
 	required_players = 15
+	max_players = 50
 	var/max_teams = 4
 	abductor_teams = 1
 	var/list/datum/mind/scientists = list()
@@ -24,7 +25,8 @@
 	world << "<b>Crew</b> - don't get abducted and stop the abductors."
 
 /datum/game_mode/abduction/pre_setup()
-	abductor_teams = max(1, min(max_teams,round(num_players()/config.abductor_scaling_coeff)))
+	// abductor_teams = max(1, min(max_teams,round(num_players()/config.abductor_scaling_coeff))) Old scaling
+	abductor_teams = max(1, min(max_teams,round(max_teams*num_players()/max_players))) // Scaling based off of max players
 	var/possible_teams = max(1,round(antag_candidates.len / 2))
 	abductor_teams = min(abductor_teams,possible_teams)
 

--- a/code/game/gamemodes/abduction/abduction.dm
+++ b/code/game/gamemodes/abduction/abduction.dm
@@ -9,7 +9,7 @@
 	antag_flag = ROLE_ABDUCTOR
 	recommended_enemies = 2
 	required_players = 15
-	max_players = 50
+	max_players = 45
 	var/max_teams = 4
 	abductor_teams = 1
 	var/list/datum/mind/scientists = list()

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -3,7 +3,7 @@
 	config_tag = "traitorchan"
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
-	required_players = 0
+	required_players = 25
 	required_enemies = 1	// how many of each type are required
 	recommended_enemies = 3
 	reroll_friendly = 1

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -55,7 +55,7 @@
 		if(playerC < required_players)
 			return 0
 		if(max_players && (playerC > max_players))
-			return 0
+			return 2
 	antag_candidates = get_players_for_role(antag_flag)
 	if(!Debug2)
 		if(antag_candidates.len < required_enemies)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -54,6 +54,8 @@
 	if(!Debug2)
 		if(playerC < required_players)
 			return 0
+		if(max_players && (playerC > max_players))
+			return 0
 	antag_candidates = get_players_for_role(antag_flag)
 	if(!Debug2)
 		if(antag_candidates.len < required_enemies)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -25,6 +25,7 @@
 	var/list/restricted_jobs = list()	// Jobs it doesn't make sense to be.  I.E chaplain or AI cultist
 	var/list/protected_jobs = list()	// Jobs that can't be traitors because
 	var/required_players = 0
+	var/max_players = 0 // Maximum number of players for a roundtype, 0 is uncapped
 	var/required_enemies = 0
 	var/recommended_enemies = 0
 	var/antag_flag = null //preferences flag such as BE_WIZARD that need to be turned on for players to be antag

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -14,9 +14,9 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 	config_tag = "gang"
 	antag_flag = ROLE_GANG
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")
-	required_players = 20
-	required_enemies = 2
-	recommended_enemies = 2
+	required_players = 25
+	required_enemies = 3
+	recommended_enemies = 3
 	enemy_minimum_age = 14
 
 ///////////////////////////
@@ -38,8 +38,10 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 		restricted_jobs += "Assistant"
 
 	//Spawn more bosses depending on server population
-	var/gangs_to_create = 2
-	if(prob(num_players() * 2))
+	var/gangs_to_create = 3
+	if(prob(num_players()) && num_players() > 1.5*required_players)
+		gangs_to_create ++
+	if(prob(num_players()) && num_players() > 2*required_players)
 		gangs_to_create ++
 
 	for(var/i=1 to gangs_to_create)

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -328,21 +328,21 @@
 					item_type = /obj/item/device/chameleon
 					pointcost = 15
 			if("thompson")
-				if(gang.points >= 55)
+				if(gang.points >= 80)
 					item_type = /obj/item/weapon/gun/projectile/automatic/tommygun
-					pointcost = 55
+					pointcost = 80
 			if("tommyammo")
-				if(gang.points >= 35)
+				if(gang.points >= 50)
 					item_type = /obj/item/ammo_box/magazine/tommygunm45
-					pointcost = 35
+					pointcost = 50
 			if(".38ammo")
-				if(gang.points >= 10)
+				if(gang.points >= 20)
 					item_type = /obj/item/ammo_box/c38
-					pointcost = 10
+					pointcost = 20
 			if(".38revolver")
-				if(gang.points >= 25)
+				if(gang.points >= 30)
 					item_type = /obj/item/weapon/gun/projectile/revolver/rigatoni
-					pointcost = 25
+					pointcost = 30
 			if("9mmammo")
 				if(gang.points >= 40)
 					item_type = /obj/item/ammo_box/magazine/uzim9mm

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -13,6 +13,7 @@
 	var/recalling = 0
 	var/outfits = 3
 	var/free_pen = 0
+	var/recall_cost = 25
 	var/promotable = 0
 
 /obj/item/device/gangtool/New() //Initialize supply point income if it hasn't already been started
@@ -58,7 +59,11 @@
 		else
 			dat += "<b>Create Gang Outfit</b> (Restocking)<br>"
 		if(isboss)
-			dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
+			dat += "([recall_cost] Influence) "
+			if(points >= recall_cost)
+				dat += "<a href='?src=\ref[src];choice=recall'>Recall Emergency Shuttle</a><br>"
+			else
+				dat += "Recall Emergency Shuttle"
 
 		dat += "<br>"
 		dat += "<B>Purchase Weapons:</B><br>"
@@ -153,8 +158,6 @@
 				dat += "<a href='?src=\ref[src];purchase=tommyammo'>Thompson Ammo</a><br>"
 			else
 				dat += "Thompson Ammo<br>"
-
-			dat += "<br>"
 
 			dat += "(80 Influence) "
 			if(points >= 80)
@@ -413,6 +416,7 @@
 				else
 					usr << "<span class='notice'>The <b>dominator</b> can be spawned only on territory controlled by your gang.</span>"
 
+					
 		if(item_type)
 			gang.points -= pointcost
 			if(ispath(item_type))
@@ -430,7 +434,15 @@
 		switch(href_list["choice"])
 			if("recall")
 				if(usr.mind == gang.bosses[1])
-					recall(usr)
+					gang.points -= recall_cost
+					gang.message_gangtools("[usr.real_name] has attempted to recall the shuttle for [recall_cost] Influence.")
+					log_game("The shuttle has attempted to be recalled by [key_name(usr)] ([gang.name] Gang) for [recall_cost] Influence.")
+					if(recall(usr))
+						recall_cost *= 2
+					else
+						gang.points += recall_spent_points
+						gang.message_gangtools("[usr.real_name]'s attempt to recall the shuttle has failed and has been refunded [recall_cost] Influence.")
+						log_game("[key_name(usr)]'s ([gang.name] Gang) recall attempt has failed and has been refunded [recall_cost] Influence.")
 			if("outfit")
 				if(outfits > 0)
 					if(gang.gang_outfit(usr,src))

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -136,28 +136,28 @@
 			else
 				dat += "Brass Knuckles<br>"
 
-			dat += "(25 Influence) "
-			if(points >= 25)
+			dat += "(30 Influence) "
+			if(points >= 30)
 				dat += "<a href='?src=\ref[src];purchase=.38revolver'>.38 Revolver</a><br>"
 			else
 				dat += ".38 Revolver<br>"
 
-			dat += "(10 Influence) "
-			if(points >= 10)
+			dat += "(20 Influence) "
+			if(points >= 20)
 				dat += "<a href='?src=\ref[src];purchase=.38ammo'>.38 Ammo</a><br>"
 			else
 				dat += ".38 Ammo<br>"
 
-			dat += "(35 Influence) "
-			if(points >= 35)
+			dat += "(50 Influence) "
+			if(points >= 50)
 				dat += "<a href='?src=\ref[src];purchase=tommyammo'>Thompson Ammo</a><br>"
 			else
 				dat += "Thompson Ammo<br>"
 
 			dat += "<br>"
 
-			dat += "(55 Influence) "
-			if(points >= 55)
+			dat += "(80 Influence) "
+			if(points >= 80)
 				dat += "<a href='?src=\ref[src];purchase=thompson'>Thompson Machinegun</a><br>"
 			else
 				dat += "Thompson Machinegun <br>"

--- a/code/game/gamemodes/gang/recaller.dm
+++ b/code/game/gamemodes/gang/recaller.dm
@@ -440,7 +440,7 @@
 					if(recall(usr))
 						recall_cost *= 2
 					else
-						gang.points += recall_spent_points
+						gang.points += recall_cost
 						gang.message_gangtools("[usr.real_name]'s attempt to recall the shuttle has failed and has been refunded [recall_cost] Influence.")
 						log_game("[key_name(usr)]'s ([gang.name] Gang) recall attempt has failed and has been refunded [recall_cost] Influence.")
 			if("outfit")

--- a/html/changelogs/Kierany9 - MaxPlayersAndGangStuff.yml
+++ b/html/changelogs/Kierany9 - MaxPlayersAndGangStuff.yml
@@ -1,0 +1,40 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Kierany9
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Adds maximum player caps for lowpop-intended gamemodes. Currently Abductors is capped at 45 players, although admins can still force these gamemodes above this playercount."
+  - tweak: "Increased the minimum playercount for Traitors+Changelings and Gangs to 25, from 0 and 20 respectively."
+  - experiment: "Increased the amount of gangs that can appear in a single round. This was previously 2-3 depending on population and is now 3-5."
+  - tweak: "Recalling the shuttle from your gangtool now costs 25 influence the first time, and doubles for every subsequent successful recall. If the recall fails, you will be refunded."
+  - tweak: "Increased the price of all of the Rigatoni Gang's equipment."


### PR DESCRIPTION
### Adds maximum reccomended playercounts:

Admins can still force these modes above the maximum, they simply won't appear in secret. This is intended for modes that don't run well enough in highpop, as they don't pose enough of a threat to the station. **Abductors now have a maximum playercount of 45** and they have been given a special scaling to acomodate this.

### Changes minimum playercounts for certain modes.

 - Traitorling: 0 -> 25
 - Gang: 20 -> 25

### Adjusts the number of gangs to appear in any given gang round.

The minimum number of gangs has been increased from 2 to 3. Extra gangs now have a chance equal to the number of players to appear at the 38 and 50 player marks. The maximum number of gangs is now five. This is why I've slightly bumped the minimum playercount. Because having two gangs and one getting fucked roundstart is never fun.

### Nerfs the Rigatoni by increasing the price of some of their items.

>let's give the rigatoni a c20 for less price than an uzi amirite oh and how about a detvolver at the price of a pistol
 - Tommy Gun: 55 -> 80 Influence
 - Tommy Gun Ammo: 35 -> 50 Influence
 - Revolver: 25 -> 30 Influence
 - Revolver Ammo: 10 -> 20 Influence

For reference, the Uzi and Sketckin are the other gang equivalents and are worth 60 and 25 influence respectively, and 40 and 10 for the ammunition. The Tommy Gun deals 10 less damage per bullet than the Uzi, but a single bullet deals enough stamina damage to incapacitate. Revolvers deal 15 less damage than the pistol but deal very nice stun and stamina damage.

### Recalling now costs 25 influence and is doubled for every successful recall.

Because this shit was annoying with three gangs, let alone five.