### PR TITLE
Canisters wrenched to connectors will now update their icons properly if the connector they were attached to is deleted.

### DIFF
--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -76,6 +76,7 @@
 	anchored = 0
 	connected_port.connected_device = null
 	connected_port = null
+	update_icon()
 	return 1
 
 /obj/machinery/portable_atmospherics/portableConnectorReturnAir()

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -120,7 +120,7 @@
 
 			// limit to 20-90 degC
 			set_temperature = dd_range(20, 90, set_temperature + value)
-
+			updateUsrDialog()
 		if("cellremove")
 			if(open && cell && !usr.get_active_hand())
 				cell.updateicon()
@@ -128,7 +128,7 @@
 				cell.add_fingerprint(usr)
 				cell = null
 				usr.visible_message("[usr] removes the power cell from \the [src].", "<span class='notice'>You remove the power cell from \the [src].</span>")
-
+				updateUsrDialog()
 
 		if("cellinstall")
 			if(open && !cell)
@@ -139,10 +139,8 @@
 					cell = C
 					C.loc = src
 					C.add_fingerprint(usr)
-
 					usr.visible_message("[usr] inserts a power cell into \the [src].", "<span class='notice'>You insert the power cell into \the [src].</span>")
-
-	updateDialog()
+					updateUsrDialog()
 
 
 /obj/machinery/space_heater/process()

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -120,7 +120,6 @@
 
 			// limit to 20-90 degC
 			set_temperature = dd_range(20, 90, set_temperature + value)
-			updateUsrDialog()
 		if("cellremove")
 			if(open && cell && !usr.get_active_hand())
 				cell.updateicon()
@@ -128,7 +127,6 @@
 				cell.add_fingerprint(usr)
 				cell = null
 				usr.visible_message("[usr] removes the power cell from \the [src].", "<span class='notice'>You remove the power cell from \the [src].</span>")
-				updateUsrDialog()
 
 		if("cellinstall")
 			if(open && !cell)
@@ -140,7 +138,6 @@
 					C.loc = src
 					C.add_fingerprint(usr)
 					usr.visible_message("[usr] inserts a power cell into \the [src].", "<span class='notice'>You insert the power cell into \the [src].</span>")
-					updateUsrDialog()
 
 
 /obj/machinery/space_heater/process()

--- a/html/changelogs/Spacedong - connectorfix.yml
+++ b/html/changelogs/Spacedong - connectorfix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Spacedong
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Canisters wrenched to connectors will now update their icons to reflect their disconnected status if the connector they are wrenched to is somehow deleted."

--- a/html/changelogs/Spacedong - spaceheaterfix.yml
+++ b/html/changelogs/Spacedong - spaceheaterfix.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Spacedong
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: "Space heater UI will now properly update upon changing the temperature or interacting with the power cell."


### PR DESCRIPTION
Fixes issue #3123.