### PR TITLE
blastco armory is now completely burglarproof (TM)

### DIFF
--- a/code/datums/uplink_item.dm
+++ b/code/datums/uplink_item.dm
@@ -105,7 +105,10 @@ var/list/uplink_items = list()
 		U.interact(user)
 		return 1
 	return 0
-
+/datum/uplink_item/equipaccess/blastco/buy(obj/item/device/uplink/U, mob/user)
+	..()
+	for(var/obj/machinery/blastco_antibuurglar in world)
+		qdel()
 /*
 //
 //	UPLINK ITEMS

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -357,5 +357,6 @@
 	qdel(src)
 
 /obj/machinery/blastco_antiburglar/HasProximity(atom/movable/AM as mob|obj)
-	if (istype(AM, /obj/effect/beam))	return
+	if (istype(AM, /obj/effect/beam))
+		return
 	src.detonate()

--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -341,6 +341,7 @@
 	layer = MOB_LAYER - 0.2
 	unacidable = 1
 
+
 /obj/machinery/blastco_antiburglar/ex_act(severity, target) //Little boom can chain a big boom
 	src.detonate()
 
@@ -354,3 +355,7 @@
 		log_game(adminlog)
 	explosion(get_turf(src),20,20,20, flame_range = 20)
 	qdel(src)
+
+/obj/machinery/blastco_antiburglar/HasProximity(atom/movable/AM as mob|obj)
+	if (istype(AM, /obj/effect/beam))	return
+	src.detonate()

--- a/html/changelogs/Spacedong - blastco.yml
+++ b/html/changelogs/Spacedong - blastco.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#   tgs (TG-ported fixes?)
+#################################
+
+# Your name.  
+author: Spacedong
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak: "Blastco armory is now completely burglar proof."


### PR DESCRIPTION
Blastco anti-burglar payloads will now instantly detonate upon sensing a mob in the armory. They will despawn once blastco is bought legitimately. Fixes issue #3254. Please codecheck this before merging.